### PR TITLE
Chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -34,12 +34,12 @@ jobs:
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest
           fi
-          echo ::set-output name=VERSION::${VERSION}
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
       - name: Get git revision
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
+          echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login ghcr.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
### Description of your changes

Closes #1302 

Update `.github/workflows/image.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=VERSION::${VERSION}
```

```yaml
echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
```

**TO-BE**

```yaml
echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
```

```yaml
echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

None

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->