### PR TITLE
Docs(contributor): Clarify and improve local development guide

### DIFF
--- a/docs/contributor/code-contribute.md
+++ b/docs/contributor/code-contribute.md
@@ -254,14 +254,17 @@ This approach creates a complete and realistic development environment. It invol
 
     First, ensure any previous KubeVela installation is removed to avoid conflicts.
     ```shell
-    helm uninstall kubevela -n vela-system
+    vela uninstall
     ```
 
-    Then, install KubeVela from the source code. This command installs the CRDs, ServiceAccount, RBAC rules, and the controller deployment itself.
+    Then, install KubeVela from the source code using the Vela CLI. This command installs the CRDs, ServiceAccount, RBAC rules, and the controller deployment itself.
     ```shell
-    # Note: This assumes you are in the root of the 'kubevela/kubevela' repository
-    helm install kubevela ./charts/vela-core -n vela-system --create-namespace
+    vela install
     ```
+    :::tip
+    Alternatively, you can use Helm directly:
+    `helm install kubevela ./charts/vela-core -n vela-system --create-namespace`
+    :::
 
 2.  **Prepare for Local Debugging**
 
@@ -286,6 +289,19 @@ This approach creates a complete and realistic development environment. It invol
     ```shell
     make core-run
     ```
+
+    <details>
+      <summary>Running from an IDE (for Debugging)</summary>
+
+      For a richer debugging experience, you can run the KubeVela controller directly from your IDE.
+
+      1.  Open the `kubevela/kubevela` project in your Go-compatible IDE (like GoLand or VSCode with the Go extension).
+      2.  Locate the main entrypoint file: `cmd/core/main.go`.
+      3.  Run or Debug this file directly from your IDE. Most IDEs will automatically detect the `main` function.
+
+      This will start the controller locally, similar to `make core-run`. You can now set breakpoints, inspect variables, and step through the code. You can also add arguments to your IDE's launch configuration, such as `--log-debug=true` to get more verbose logs.
+
+    </details>
 
 :::caution
 By removing the webhooks, you will not be able to test features that rely on the admission controller (like some definition validation or pod injection features) in this mode.


### PR DESCRIPTION
### Description

This Pull Request addresses the confusion and incompleteness in the local development guide (`docs/contributor/code-contribute.md`), which was causing a suboptimal onboarding experience for new contributors.

Specifically, it resolves the issues where:
- The "quick start" `make core-run` method led to an incomplete environment (missing ServiceAccount, RBAC) without proper explanation.
- The guide for a complete setup (`Debugging Locally with Remote KubeVela Environment`) lacked the crucial `helm install` command.

This PR implements the following changes:
1.  **Added a `:::caution` note** to the "Run Vela Core" section, explicitly warning that the `make core-run` quick-start method is incomplete and uses local `kubeconfig` credentials, not a full in-cluster setup.
2.  **Rewrote the `Debugging Locally with Remote KubeVela Environment` section** into a comprehensive, step-by-step guide. This now includes the necessary `helm install` command, instructions for scaling down the in-cluster controller, and removing webhooks, providing a self-contained and realistic development workflow.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page. (Not applicable, existing page modified)
- [x] Run `yarn start` to ensure the changes has taken effect.

### Related Issue
- Fixes #1380

### Special notes for your reviewer

Please pay close attention to the following:
- The clarity and accuracy of the new `:::caution` note in the "Run Vela Core" section.
- The completeness and correctness of the new step-by-step guide in the "Debugging Locally with Remote KubeVela Environment" section, especially the `helm install` command and the sequence of operations.
- The technical correction made to the `kubectl delete ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` commands, where the `-n vela-system` flag was removed as these are cluster-scoped resources.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarifies the local development guide to prevent incomplete setups. Adds a realistic, step-by-step workflow for running vela-core locally against a Helm-installed cluster.

- **Bug Fixes**
  - Added a caution in "Run Vela Core" explaining that core-run uses your kubeconfig and doesn’t create ServiceAccount/RBAC.
  - Rewrote "Debugging Locally with Remote KubeVela Environment" with Helm install, scaling down the in-cluster controller, removing cluster-scoped webhooks (no -n), and running core-run; noted webhook-dependent features can’t be tested in this mode.

<!-- End of auto-generated description by cubic. -->

