### PR TITLE
Docs(installation): Update Kubernetes version compatibility to v1.31

### DIFF
--- a/docs/installation/kubernetes.mdx
+++ b/docs/installation/kubernetes.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ### 1. Kubernetes Requirements:
 
-- Kubernetes cluster >= `v1.19 && <= v1.31`
+- Kubernetes cluster `>= v1.19 && <= v1.31`
 
 KubeVela relies on Kubernetes as a control plane. The control plane could be any managed Kubernetes offering or your own clusters, such as:
 

--- a/docs/installation/kubernetes.mdx
+++ b/docs/installation/kubernetes.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ### 1. Kubernetes Requirements:
 
-- Kubernetes cluster `>= v1.19 && <= v1.29`
+- Kubernetes cluster >= v1.19 && <= v1.31
 
 KubeVela relies on Kubernetes as a control plane. The control plane could be any managed Kubernetes offering or your own clusters, such as:
 

--- a/docs/installation/kubernetes.mdx
+++ b/docs/installation/kubernetes.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ### 1. Kubernetes Requirements:
 
-- Kubernetes cluster >= v1.19 && <= v1.31
+- Kubernetes cluster >= `v1.19 && <= v1.31`
 
 KubeVela relies on Kubernetes as a control plane. The control plane could be any managed Kubernetes offering or your own clusters, such as:
 


### PR DESCRIPTION
### Description

This Pull Request updates the Kubernetes version compatibility information in the installation guide (`docs/installation/kubernetes.mdx`).

Previously, the documentation stated that KubeVela supports Kubernetes clusters up to `v1.29`. This PR updates that information to reflect that KubeVela now supports Kubernetes clusters up to `v1.31`.

The line `- Kubernetes cluster >= v1.19 && <= v1.29` has been changed to `- Kubernetes cluster >= v1.19 && <= v1.31`.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page. (Not applicable, existing page modified)
- [x] Run `yarn start` to ensure the changes has taken effect.

### Related Issue
- Fixes #1382

### Special notes for your reviewer

Please verify that the updated Kubernetes version compatibility (`v1.19 && <= v1.31`) accurately reflects the current support for KubeVela.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the installation guide to reflect Kubernetes support through v1.31. Replaces ">= v1.19 && <= v1.29" with ">= v1.19 && <= v1.31" in docs/installation/kubernetes.mdx.

<!-- End of auto-generated description by cubic. -->

