### PR TITLE
Feat: 7019 Support re-running workflows and ensure passed data is upd…

### DIFF
--- a/docs/end-user/workflow/operations.md
+++ b/docs/end-user/workflow/operations.md
@@ -53,6 +53,28 @@ You can use `vela workflow restart` to restart an executing workflow.
 vela workflow restart my-app
 ```
 
+### Scheduled Restarts
+
+For automated restarts, workflows can schedule their own re-execution using the `restart-workflow` step. This enables periodic tasks, delayed execution, or time-based orchestration. See the [restart-workflow step documentation](./built-in-workflow-defs.md#restart-workflow) for examples.
+
+You can also schedule restarts by adding the `app.oam.dev/restart-workflow` annotation to an Application:
+
+```bash
+# One-time restart at specific time (RFC3339 format)
+kubectl annotate application my-app app.oam.dev/restart-workflow="2025-01-20T15:00:00Z"
+
+# Recurring restart every 24 hours
+kubectl annotate application my-app app.oam.dev/restart-workflow="24h"
+
+# Immediate restart
+kubectl annotate application my-app app.oam.dev/restart-workflow="true"
+```
+
+The annotation accepts three formats:
+- **RFC3339 timestamp**: One-time restart at the specified time
+- **Duration** (e.g., "5m", "1h", "24h"): Recurring restarts at the specified interval
+- **"true"**: Immediate restart
+
 ## Check the logs of the workflow
 
 You can use `vela workflow logs` to check the logs of the workflow.


### PR DESCRIPTION
…ated during dispatch

### Description of your changes

copilot:all

Feature PR: https://github.com/kubevela/kubevela/pull/7025

- Fix: Detect component property changes during multi-stage dispatch to trigger re-dispatch when workflow context passes different values to components
 - Feature: Add workflow restart scheduling via `app.oam.dev/restart-workflow` annotation supporting one-time and recurring restarts
 - Feature: Add `restart-workflow` WorkflowStepDefinition allowing workflows to self-schedule restarts using `at` (specific time), `after` (relative duration), or `every` (recurring interval) parameters

Fixes https://github.com/kubevela/kubevela/issues/7019

I have:

- [x Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workflow restart scheduling and a new restart-workflow step, and fixes re-dispatch when component inputs change during a run. This lets workflows re-run reliably and schedule one-time or recurring restarts.

- New Features
  - Support scheduling restarts via the app.oam.dev/restart-workflow annotation (timestamp, duration interval, or immediate).
  - Add restart-workflow step with at, after, and every parameters for self-scheduled restarts.

- Bug Fixes
  - Detect component property changes across multi-stage dispatch and re-dispatch components when context values differ.

<sup>Written for commit 7e7a92e208a1db2093d8c8b3b44eaf2886d9accc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

