### PR TITLE
Fix: 7032 Adds component type to structured log output

### DIFF
--- a/docs/platform-engineers/status/application_health_status_metrics.md
+++ b/docs/platform-engineers/status/application_health_status_metrics.md
@@ -180,6 +180,7 @@ Each log entry contains:
     "services": [
       {
         "name": "frontend",
+        "type": "webservice",
         "namespace": "default",
         "cluster": "local",
         "healthy": true,
@@ -187,7 +188,21 @@ Each log entry contains:
         "details": {
           "readyReplicas": "3",
           "totalReplicas": "3"
-        }
+        },
+        "traits": [
+          {
+            "type": "ingress",
+            "healthy": true,
+            "message": "Ingress configured",
+            "details": {
+              "host": "example.com"
+            }
+          },
+          {
+            "type": "autoscaler",
+            "healthy": true
+          }
+        ]
       }
     ],
     "workflow": {
@@ -217,11 +232,19 @@ Each log entry contains:
 
 **Service Details** (for each service):
 - `name`: Service/component name
+- `type`: Component type (e.g., webservice, worker, task)
 - `namespace`: Service namespace (may differ in multi-cluster)
 - `cluster`: Target cluster name
 - `healthy`: Service health status
 - `message`: Human-readable status message
 - `details`: Additional status details (if configured)
+- `traits`: Array of trait statuses (if traits are attached)
+
+**Trait Status** (for each trait in a service):
+- `type`: Trait type (e.g., ingress, autoscaler, sidecar)
+- `healthy`: Trait health status
+- `message`: Human-readable trait status message (if available)
+- `details`: Additional trait status details (if configured)
 
 **Workflow Status**:
 - `app_revision`: Application revision

--- a/versioned_docs/version-v1.10/platform-engineers/status/application_health_status_metrics.md
+++ b/versioned_docs/version-v1.10/platform-engineers/status/application_health_status_metrics.md
@@ -1,4 +1,5 @@
 ---
+---
 title: Application Health & Status Metrics
 ---
 
@@ -180,6 +181,7 @@ Each log entry contains:
     "services": [
       {
         "name": "frontend",
+        "type": "webservice",
         "namespace": "default",
         "cluster": "local",
         "healthy": true,
@@ -187,7 +189,21 @@ Each log entry contains:
         "details": {
           "readyReplicas": "3",
           "totalReplicas": "3"
-        }
+        },
+        "traits": [
+          {
+            "type": "ingress",
+            "healthy": true,
+            "message": "Ingress configured",
+            "details": {
+              "host": "example.com"
+            }
+          },
+          {
+            "type": "autoscaler",
+            "healthy": true
+          }
+        ]
       }
     ],
     "workflow": {
@@ -217,11 +233,19 @@ Each log entry contains:
 
 **Service Details** (for each service):
 - `name`: Service/component name
+- `type`: Component type (e.g., webservice, worker, task)
 - `namespace`: Service namespace (may differ in multi-cluster)
 - `cluster`: Target cluster name
 - `healthy`: Service health status
 - `message`: Human-readable status message
 - `details`: Additional status details (if configured)
+- `traits`: Array of trait statuses (if traits are attached)
+
+**Trait Status** (for each trait in a service):
+- `type`: Trait type (e.g., ingress, autoscaler, sidecar)
+- `healthy`: Trait health status
+- `message`: Human-readable trait status message (if available)
+- `details`: Additional trait status details (if configured)
 
 **Workflow Status**:
 - `app_revision`: Application revision


### PR DESCRIPTION
### Description of your changes

Updates docs for https://github.com/kubevela/kubevela/pull/7033

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Application Health Status docs to include the component type in structured log outputs and to document trait statuses. The example now shows a service "type" field and a "traits" array with trait health, message, and details.

<sup>Written for commit b9a25992561a726fe7b29e5a035062a7c8edc561. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

