### PR TITLE
Feat: Immutable Parameters

### DIFF
--- a/docs/platform-engineers/cue/basic.md
+++ b/docs/platform-engineers/cue/basic.md
@@ -583,3 +583,4 @@ In the following sections, we'll start to learn how KubeVela use CUE to glue res
 ## Next
 
 * Learn how to use CUE to extend KubeVela by [Managing Definition](./definition-edit.md).
+* Learn how to use [Parameter Markers](./parameter-markers.md) such as `+usage` and `+immutable` to control parameter behaviour.

--- a/docs/platform-engineers/cue/parameter-markers.md
+++ b/docs/platform-engineers/cue/parameter-markers.md
@@ -1,0 +1,147 @@
+---
+title: Parameter Markers
+---
+
+KubeVela supports special comment markers in CUE `parameter` blocks that control how parameters behave at runtime. These markers are recognised by the KubeVela controller and its admission webhook.
+
+## Available Markers
+
+| Marker | Applies to | Effect |
+|--------|-----------|--------|
+| `// +usage=<description>` | Any field | Sets the human-readable description shown in the UI and `vela show` output |
+| `// +short=<alias>` | Any field | Provides a short alias for the field name |
+| `// +immutable` | Any field | Prevents the field from being changed or removed after the Application is first created |
+
+## The `+usage` Marker
+
+The `// +usage=<description>` marker sets the human-readable description for a parameter field. This description is shown in the output of `vela show` and in the VelaUX UI.
+
+```cue
+template: {
+    parameter: {
+        // +usage=The container image to run, e.g. nginx:1.21
+        image: string
+        // +usage=Number of replicas to run
+        replicas: *1 | int
+    }
+}
+```
+
+```shell
+$ vela show my-component
+# Properties
++----------+----------------------------+--------+----------+---------+
+|   NAME   |        DESCRIPTION         |  TYPE  | REQUIRED | DEFAULT |
++----------+----------------------------+--------+----------+---------+
+| image    | The container image to run | string | true     |         |
+| replicas | Number of replicas to run  | int    | false    | 1       |
++----------+----------------------------+--------+----------+---------+
+```
+
+## The `+short` Marker
+
+The `// +short=<alias>` marker sets a short alias for a field name, stored in the parameter metadata and available to tooling that builds on the KubeVela API.
+
+```cue
+template: {
+    parameter: {
+        // +usage=The container image to run
+        // +short=i
+        image: string
+    }
+}
+```
+
+## The `+immutable` Marker
+
+The `// +immutable` marker prevents a parameter field from being mutated once it has been set in an Application. This is useful for fields that should be fixed for the lifetime of a workload, such as a tenant identifier or a target cluster.
+
+### Marking a field as immutable
+
+Add `// +immutable` as a comment on the line immediately before the field declaration in the `parameter` block:
+
+```cue
+"my-component": {
+    type: "component"
+    ...
+}
+template: {
+    parameter: {
+        // +usage=The tenant this workload belongs to — cannot be changed after creation
+        // +immutable
+        tenant: string
+
+        // +usage=Container image (mutable)
+        image: string
+    }
+}
+```
+
+### Nested fields
+
+`// +immutable` can be applied to individual fields within a nested struct. Only the marked field is frozen — sibling fields remain mutable:
+
+```cue
+template: {
+    parameter: {
+        governance: {
+            // +immutable
+            tenant: string    // frozen
+            region: string    // still mutable
+        }
+        image: string         // still mutable
+    }
+}
+```
+
+Marking a struct field itself (rather than a leaf) freezes the entire subtree:
+
+```cue
+template: {
+    parameter: {
+        // +immutable
+        governance: {
+            tenant: string    // frozen (entire struct is frozen)
+            region: string    // frozen
+        }
+    }
+}
+```
+
+### Validation behaviour
+
+When an Application is updated, the validating webhook checks all `// +immutable` fields:
+
+- **Field unchanged** — allowed
+- **Field not yet set** — first-time population is always allowed
+- **Field changed** — rejected with an error showing the current and attempted values:
+  ```
+  spec.components[0].properties[governance.tenant]: Forbidden: immutable field cannot be changed (current: "acme", new: "other")
+  ```
+- **Field removed** — rejected with an error showing the current value
+
+### Bypassing immutability
+
+In exceptional cases (e.g. a controlled migration), you can bypass all immutability checks by adding the `app.oam.dev/force-param-mutations: "true"` annotation to the Application:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+  annotations:
+    app.oam.dev/force-param-mutations: "true"
+spec:
+  ...
+```
+
+Remove the annotation after the update to re-enable immutability enforcement.
+
+### OpenAPI schema extension
+
+When KubeVela generates the OpenAPI v3 schema for a definition (stored in the `schema-<name>` ConfigMap), fields marked `// +immutable` will have the `x-immutable: true` extension set on their schema entry.
+
+## Next
+
+- [Generating OpenAPI Schema](../openapi-v3-json-schema.md)
+- [Managing Definitions](./definition-edit.md)

--- a/docs/platform-engineers/openapi-v3-json-schema.md
+++ b/docs/platform-engineers/openapi-v3-json-schema.md
@@ -74,4 +74,4 @@ Specifically, this schema is generated based on `parameter` section in capabilit
 
 ## Next
 
-Refer to [UX of Definition](../reference/ui-schema.md)
+* Refer to [UX of Definition](../reference/ui-schema.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -312,6 +312,7 @@ module.exports = {
         {
           'Manage Definition with CUE': [
             'platform-engineers/cue/basic',
+            'platform-engineers/cue/parameter-markers',
             'platform-engineers/cue/definition-edit',
             'platform-engineers/components/custom-component',
             'platform-engineers/traits/customize-trait',

--- a/versioned_docs/version-v1.10/platform-engineers/status/application_health_status_metrics.md
+++ b/versioned_docs/version-v1.10/platform-engineers/status/application_health_status_metrics.md
@@ -1,5 +1,4 @@
 ---
----
 title: Application Health & Status Metrics
 ---
 


### PR DESCRIPTION
### Description of your changes

Documentation for https://github.com/kubevela/kubevela/pull/7059

> Adds support for marking CUE definition parameter fields as immutable using a // +immutable comment marker. Once set, these fields cannot be changed or removed on Application update.

Also adds some missing documentation for other field markers (// +usage and // +short)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new docs page for CUE parameter markers focused on +immutable, covering usage, validation, and schema behavior. Updates related pages and the sidebar, and fixes a minor page header.

- **New Features**
  - New "Parameter Markers" page covering +usage, +short, and +immutable with examples.
  - Details on nested and struct-level immutability, validation errors on updates, and the force override annotation (app.oam.dev/force-param-mutations).
  - Notes on OpenAPI v3 schema generation with x-immutable.
  - Linked from CUE Basics; sidebar updated; minor formatting cleanups in related docs.

- **Bug Fixes**
  - Fixed duplicate front matter in the v1.10 Application Health & Status Metrics page header.

<sup>Written for commit 097af42ede7eca18d8163fa222ab459e387db236. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

