### PR TITLE
Docs: use archive link for deleted GitOps blog post

### DIFF
--- a/docs/case-studies/gitops.md
+++ b/docs/case-studies/gitops.md
@@ -6,7 +6,7 @@ title:  Overview of GitOps
 This section will introduce how to use KubeVela in GitOps area and why.
 :::
 
-GitOps is a continuous delivery method that allows developers to automatically deploy applications by changing code and declarative configurations in a Git repository, with "git-centric" operations such as PR and commit. For detailed benefits of GitOps, you can refer to [this blog](https://www.weave.works/blog/what-is-gitops-really).
+GitOps is a continuous delivery method that allows developers to automatically deploy applications by changing code and declarative configurations in a Git repository, with "git-centric" operations such as PR and commit. For detailed benefits of GitOps, you can refer to [this blog](https://web.archive.org/web/20231124194854/https://www.weave.works/blog/what-is-gitops-really).
 
 KubeVela as a declarative application delivery control plane can be naturally used in GitOps approach, and this will provide below extra bonus to end users alongside with GitOps benefits:
 


### PR DESCRIPTION
### Description of your changes

This updates the link to the weave.works blog post, so it now points to an archived version (using archive.org). The blog post is currently linked in https://kubevela.io/docs/case-studies/gitops/, but the destination domain seems to have been taken over and now redirects to a thai gambling site.

Screen record of current state:

https://github.com/user-attachments/assets/81648e99-3aa6-43f5-a719-e05e1d2c6134

---

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.

### Special notes for your reviewer

I've taken the most recent link from archive.org that I could find for the used URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the GitOps blog reference with a Wayback Machine snapshot to fix the broken `weave.works` link. This prevents a spam redirect and keeps the docs accurate.

<sup>Written for commit 0122794edef4b7376c67e684ee69080c3cecc499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

