### PR TITLE
feat: add helmchart component definition documentation

### DIFF
--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -633,7 +633,6 @@ spec:
  chart | Chart source configuration | [chart](#chart-helmchart) | true |  
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
  values | Inline values (highest priority) | map[string]interface{} | false |  
- healthStatus | Health status criteria - defines when the Helm deployment is considered healthy | [[]healthStatus](#healthstatus-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
 
@@ -654,35 +653,10 @@ spec:
  namespace | Target namespace (defaults to Application namespace) | string | false |  
 
 
-#### healthStatus (helmchart)
-
- Name | Description | Type | Required | Default 
- ---- | ----------- | ---- | -------- | ------- 
- resource | Resource to check | [resource](#resource-helmchart) | true |  
- condition | Health condition to verify | [condition](#condition-helmchart) | true |  
-
-
-##### resource (helmchart)
-
- Name | Description | Type | Required | Default 
- ---- | ----------- | ---- | -------- | ------- 
- kind | Resource kind (e.g., "Deployment", "StatefulSet", "Job", "Service") | string | true |  
- name | Optional: specific resource name (if not specified, checks first of kind) | string | false |  
-
-
-##### condition (helmchart)
-
- Name | Description | Type | Required | Default 
- ---- | ----------- | ---- | -------- | ------- 
- type | The type must match an actual Kubernetes .status.conditions[].type value | string | true |  
- status | Expected status (default: "True", use "False" for conditions like Progressing) | string | false | "True" 
-
-
 #### options (helmchart)
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- includeCRDs | Install CRDs from chart | bool | false | true 
  skipTests | Skip test resources | bool | false | true 
  skipHooks | Skip hook resources | bool | false | false 
  createNamespace | Create namespace if it doesn't exist | bool | false | true 
@@ -690,21 +664,9 @@ spec:
  maxHistory | Revisions to keep | int | false | 10 
  atomic | Rollback on failure | bool | false | false 
  wait | Wait for resources | bool | false | false 
- waitTimeout | Wait timeout | string | false | "10m" 
  force | Force resource updates | bool | false | false 
  recreatePods | Recreate pods on upgrade | bool | false | false 
  cleanupOnFail | Cleanup on failure | bool | false | false 
- cache | Cache configuration | [cache](#cache-helmchart) | false |  
-
-
-##### cache (helmchart)
-
- Name | Description | Type | Required | Default 
- ---- | ----------- | ---- | -------- | ------- 
- key | Cache key prefix (defaults to `"{context.appName}-{context.name}"`) | string | false |  
- ttl | TTL for this specific chart (overrides automatic detection) | string | false |  
- immutableTTL | TTL for semantic versions (1.2.3, v2.0.0) | string | false | "24h" 
- mutableTTL | TTL for mutable tags (latest, dev, main) | string | false | "5m" 
 
 
 ## K8s-Objects

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -701,7 +701,7 @@ spec:
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- key | Cache key prefix (defaults to "{context.appName}-{context.name}") | string | false |  
+ key | Cache key prefix (defaults to `"{context.appName}-{context.name}"`) | string | false |  
  ttl | TTL for this specific chart (overrides automatic detection) | string | false |  
  immutableTTL | TTL for semantic versions (1.2.3, v2.0.0) | string | false | "24h" 
  mutableTTL | TTL for mutable tags (latest, dev, main) | string | false | "5m" 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -602,7 +602,7 @@ spec:
 
 ## Helmchart
 
-> **Note:** This component is still under development. The Helm pre-delete and post-delete hooks doesn't work with this.
+> **Note:** There is a known limitation with pre-delete and post-delete hook functionality that will be addressed in later releases. Currently, only public chart repositories are supported — authentication for private repositories is on the roadmap.
 
 ### Description
 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -600,6 +600,113 @@ spec:
  hostnames |  | []string | true |  
 
 
+## Helmchart
+
+> **Note:** This component is still under development. The Helm pre-delete and post-delete hooks doesn't work with this.
+
+### Description
+
+Deploy Helm charts natively in KubeVela
+
+### Examples (helmchart)
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: sample-helmchart
+spec:
+  components:
+    - name: my-chart
+      type: helmchart
+      properties:
+        chart:
+          source: oci://ghcr.io/org/charts/app
+          version: "1.0.0"
+```
+
+### Specification (helmchart)
+
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ chart | Chart source configuration | [chart](#chart-helmchart) | true |  
+ release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
+ values | Inline values (highest priority) | map[string]interface{} | false |  
+ healthStatus | Health status criteria - defines when the Helm deployment is considered healthy | [[]healthStatus](#healthstatus-helmchart) | false |  
+ options | Rendering options | [options](#options-helmchart) | false |  
+
+
+#### chart (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ source | Chart location - automatically detected based on format (OCI, Direct URL, Repo chart) | string | true |  
+ repoURL | Repository URL for repository-based charts | string | false |  
+ version | Version/tag for repository and OCI charts (ignored for direct URLs) | string | false | "latest" 
+
+
+#### release (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ name | Release name (defaults to component name) | string | false |  
+ namespace | Target namespace (defaults to Application namespace) | string | false |  
+
+
+#### healthStatus (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ resource | Resource to check | [resource](#resource-helmchart) | true |  
+ condition | Health condition to verify | [condition](#condition-helmchart) | true |  
+
+
+##### resource (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ kind | Resource kind (e.g., "Deployment", "StatefulSet", "Job", "Service") | string | true |  
+ name | Optional: specific resource name (if not specified, checks first of kind) | string | false |  
+
+
+##### condition (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ type | The type must match an actual Kubernetes .status.conditions[].type value | string | true |  
+ status | Expected status (default: "True", use "False" for conditions like Progressing) | string | false | "True" 
+
+
+#### options (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ includeCRDs | Install CRDs from chart | bool | false | true 
+ skipTests | Skip test resources | bool | false | true 
+ skipHooks | Skip hook resources | bool | false | false 
+ createNamespace | Create namespace if it doesn't exist | bool | false | true 
+ timeout | Rendering timeout | string | false | "5m" 
+ maxHistory | Revisions to keep | int | false | 10 
+ atomic | Rollback on failure | bool | false | false 
+ wait | Wait for resources | bool | false | false 
+ waitTimeout | Wait timeout | string | false | "10m" 
+ force | Force resource updates | bool | false | false 
+ recreatePods | Recreate pods on upgrade | bool | false | false 
+ cleanupOnFail | Cleanup on failure | bool | false | false 
+ cache | Cache configuration | [cache](#cache-helmchart) | false |  
+
+
+##### cache (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ key | Cache key prefix (defaults to "{context.appName}-{context.name}") | string | false |  
+ ttl | TTL for this specific chart (overrides automatic detection) | string | false |  
+ immutableTTL | TTL for semantic versions (1.2.3, v2.0.0) | string | false | "24h" 
+ mutableTTL | TTL for mutable tags (latest, dev, main) | string | false | "5m" 
+
+
 ## K8s-Objects
 
 ### Description


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Helmchart` component docs with examples and full field specs, aligned with Helm CUE definitions, and fixes doc validation issues. Pre/post-delete hooks and private repo auth are not supported yet (public charts only).

- **New Features**
  - Adds a new “Helmchart” section in `docs/end-user/components/references.md`.
  - Includes a sample Application using an OCI chart.
  - Documents `chart`/`release`/`values` and `options` (`skipTests`, `skipHooks`, `createNamespace`, `timeout`, `maxHistory`, `atomic`, `wait`, `force`, `recreatePods`, `cleanupOnFail`).

- **Bug Fixes**
  - Fixes docs validation checks and example syntax.

<sup>Written for commit 0badda5cdfd66a0030e1993812f1aac964e25582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

