### PR TITLE
docs(defkit): enhance documentation with validator examples and usage

### DIFF
--- a/docs/platform-engineers/defkit/definition-component.md
+++ b/docs/platform-engineers/defkit/definition-component.md
@@ -67,6 +67,16 @@ output: {
 }
 ```
 
+## OmitWorkloadType
+
+For custom resource types (e.g., Crossplane claims), defkit auto-generates a `workload.type` field. If your CUE source does not include this field, suppress it with `OmitWorkloadType()`:
+
+```go
+comp := defkit.NewComponent("my-claim").
+    Workload("database.example.com/v1alpha1", "PostgreSQL").
+    OmitWorkloadType()
+```
+
 ## AutodetectWorkload
 
 Use `.AutodetectWorkload()` instead of `.Workload()` when the component template can produce different resource kinds depending on parameters (e.g., `k8s-objects` accepts arbitrary manifests, `ref-objects` references existing resources).

--- a/docs/platform-engineers/defkit/param-chain-methods.md
+++ b/docs/platform-engineers/defkit/param-chain-methods.md
@@ -120,11 +120,442 @@ parameter: {
 ```go title="Go — defkit"
 name := defkit.String("name").Pattern("^[a-z]+$")
 slug := defkit.String("slug").MinLen(1).MaxLen(63)
+defkit.String("name").NotEmpty()                    // string & !=""
 ```
 
 ```cue title="CUE — generated"
 name?: string & =~"^[a-z]+$"
 slug?: string & strings.MinRunes(1) & strings.MaxRunes(63)
+```
+
+| Generated CUE | Go Definition |
+|:-------------|:-------------|
+| `name: string & =~"^[a-z]+$"` | `String("name").Pattern("^[a-z]+$")` |
+| `name: string & !=""` | `String("name").NotEmpty()` |
+
+:::tip
+For negative regex constraints (CUE `!~`), use a [Validator](#validators) with `LocalField().Matches()` instead of an inline type constraint. For example, to reject strings ending with a hyphen: `Validate("must not end with -").FailWhen(LocalField("region").Matches(".*-$"))`.
+:::
+
+## Array Constraints
+
+```go
+defkit.Array("ports").MinItems(1).MaxItems(10)
+defkit.StringList("origins").NotEmpty()                                        // [...(string & !="")]
+defkit.Array("methods").OfEnum("GET", "POST", "PUT", "DELETE")                 // [...("GET" | "POST" | ...)]
+```
+
+| Generated CUE | Go Definition |
+|:-------------|:-------------|
+| `origins?: [...(string & !="")]` | `StringList("origins").NotEmpty()` |
+| `methods?: [...("GET" \| "POST")]` | `Array("methods").OfEnum("GET", "POST")` |
+
+- **`NotEmpty()`** -- constrains each *element* to be non-empty (`!=""`). Same as `StringParam.NotEmpty()` but applied at the element level.
+- **`OfEnum(values...)`** -- constrains each element to one of the given values.
+
+:::tip
+To validate that an array itself has at least one item, use a [Validator](#validators) on the parent struct or array:
+```go
+defkit.Array("corsRules").WithFields(
+    defkit.Array("allowedMethods").OfEnum("GET", "POST"),
+).Validators(
+    defkit.Validate("at least one method required").
+        FailWhen(defkit.LocalField("allowedMethods").IsEmpty()),
+)
+```
+This keeps the framework generic — any validation logic can be expressed through `Validators()` without needing a dedicated method for each pattern.
+:::
+
+### Map Constraints
+
+```go
+defkit.Object("governance").Closed()  // close({...}) -- rejects extra fields
+```
+
+## Validators
+
+Validators express cross-field validation rules using the CUE `_validate*` block pattern. They emit:
+
+```cue
+_validateName: {
+    "error message": true
+    if <failCondition> {
+        "error message": false
+    }
+}
+```
+
+Validators can be attached at three levels:
+- **Component-level** -- `defkit.NewComponent(...).Validators(...)`
+- **Inside structs** -- `defkit.Object(...).Validators(...)`
+- **Inside array elements** -- `defkit.Array(...).Validators(...)`
+
+### Validate / FailWhen / WithName
+
+The core validator builder chain:
+
+```go title="basic_validator.go"
+defkit.Validate("tenantName must not end with a hyphen").  // error message
+    WithName("_validateTenantName").                        // CUE variable name
+    FailWhen(defkit.LocalField("tenantName").Matches(".*-$"))  // condition that triggers failure
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+_validateTenantName: {
+    "tenantName must not end with a hyphen": true
+    if tenantName =~ ".*-$" {
+        "tenantName must not end with a hyphen": false
+    }
+}
+```
+
+</details>
+
+### OnlyWhen -- Guarded Validator
+
+A guarded validator is only active when a condition is true. The entire block is wrapped in an `if` guard:
+
+```go title="guarded_validator.go"
+defkit.Validate("versioningEnabled must be true when replication is set").
+    WithName("_validateVersioning").
+    OnlyWhen(defkit.Or(
+        defkit.LocalField("replicationConfiguration").IsSet(),
+        defkit.LocalField("objectLock").IsSet(),
+    )).
+    FailWhen(defkit.LocalField("versioningEnabled").Eq(false))
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+if replicationConfiguration != _|_ || objectLock != _|_ {
+    _validateVersioning: {
+        "versioningEnabled must be true when replication is set": true
+        if versioningEnabled == false {
+            "versioningEnabled must be true when replication is set": false
+        }
+    }
+}
+```
+
+</details>
+
+### MapParam.Validators -- Validators Inside Structs
+
+Attach validators to an `Object` parameter. They are emitted inside the struct:
+
+```go title="governance_validators.go"
+governance := defkit.Object("governance").Closed().
+    WithFields(
+        defkit.String("tenantName").NotEmpty(),
+        defkit.String("departmentCode").NotEmpty(),
+    ).
+    Validators(
+        defkit.Validate("tenantName must not end with a hyphen").
+            WithName("_validateTenantName").
+            FailWhen(defkit.LocalField("tenantName").Matches(".*-$")),
+        defkit.Validate("departmentCode must be numeric").
+            WithName("_validateDeptCode").
+            FailWhen(defkit.Not(defkit.LocalField("departmentCode").Matches("^[0-9]+$"))),
+    )
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+governance: close({
+    tenantName: string & !=""
+    departmentCode: string & !=""
+    _validateTenantName: {
+        "tenantName must not end with a hyphen": true
+        if tenantName =~ ".*-$" {
+            "tenantName must not end with a hyphen": false
+        }
+    }
+    _validateDeptCode: {
+        "departmentCode must be numeric": true
+        if !(departmentCode =~ "^[0-9]+$") {
+            "departmentCode must be numeric": false
+        }
+    }
+})
+```
+
+</details>
+
+### ArrayParam.Validators -- Validators Inside Array Elements
+
+Validators on arrays are emitted inside each element struct:
+
+```go title="lifecycle_validators.go"
+defkit.Array("lifecycleRules").Optional().
+    WithFields(
+        defkit.String("id").Optional().NotEmpty(),
+        defkit.Array("expiration").Optional().WithFields(...),
+        defkit.Array("transition").Optional().WithFields(...),
+    ).
+    Validators(
+        defkit.Validate("id is required").
+            WithName("_validateId").
+            FailWhen(defkit.LocalField("id").NotSet()),
+        defkit.Validate("at least one sub-rule is required").
+            WithName("_validateLifecycleRules").
+            FailWhen(defkit.And(
+                defkit.LocalField("expiration").NotSet(),
+                defkit.LocalField("transition").NotSet(),
+            )),
+    )
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+lifecycleRules?: [...{
+    id?: string & !=""
+    expiration?: [...]
+    transition?: [...]
+    _validateId: {
+        "id is required": true
+        if id == _|_ {
+            "id is required": false
+        }
+    }
+    _validateLifecycleRules: {
+        "at least one sub-rule is required": true
+        if expiration == _|_ && transition == _|_ {
+            "at least one sub-rule is required": false
+        }
+    }
+}]
+```
+
+</details>
+
+### Component-Level Validators
+
+Validators attached to the component are emitted at the top level of the `parameter:` block:
+
+```go title="component_validators.go"
+name := defkit.String("name").NotEmpty()
+
+defkit.NewComponent("my-component").
+    Params(name).
+    Validators(
+        defkit.Validate("name is too long").
+            WithName("_validateNameLength").
+            FailWhen(defkit.LenOf(defkit.Plus(
+                defkit.Lit("prefix-"), name,
+            )).Gt(63)),
+    )
+```
+
+### Mutual Exclusion Pattern
+
+A common pattern: two fields where exactly one must be set:
+
+```go title="mutual_exclusion.go"
+defkit.Array("Statement").WithFields(
+    defkit.Object("Principal").Optional(),
+    defkit.Object("NotPrincipal").Optional(),
+).Validators(
+    defkit.Validate("Either Principal or NotPrincipal is required").
+        WithName("_validatePrincipalRequired").
+        FailWhen(defkit.And(
+            defkit.LocalField("Principal").NotSet(),
+            defkit.LocalField("NotPrincipal").NotSet(),
+        )),
+    defkit.Validate("Principal and NotPrincipal cannot both be set").
+        WithName("_validatePrincipalExclusive").
+        FailWhen(defkit.And(
+            defkit.LocalField("Principal").IsSet(),
+            defkit.LocalField("NotPrincipal").IsSet(),
+        )),
+)
+```
+
+### Nested Field and Array Index Access
+
+`LocalField` supports dot-path and array index syntax for cross-field checks across nested structures:
+
+```go title="nested_field_access.go"
+// Check a nested field inside a struct
+defkit.Validate("Principal must have at least one AWS entry").
+    WithName("_validatePrincipalAWS").
+    OnlyWhen(defkit.And(
+        defkit.LocalField("Principal").IsSet(),
+        defkit.LocalField("Principal.AWS").IsSet(),
+    )).
+    FailWhen(defkit.LocalField("Principal.AWS").IsEmpty())
+
+// Check a field inside the first element of an array
+defkit.Validate("transition days must be less than expiration days").
+    WithName("_validateTransitionDays").
+    OnlyWhen(defkit.LocalField("days").IsSet()).
+    FailWhen(defkit.And(
+        defkit.LocalField("expiration").IsSet(),
+        defkit.LocalField("expiration").LenGt(0),
+        defkit.LocalField("expiration[0].days").IsSet(),
+        defkit.LocalField("days").Gte(defkit.LocalField("expiration[0].days")),
+    ))
+```
+
+### Date Comparison with TimeParse
+
+For CUE `time.Parse()` comparisons between date fields:
+
+```go title="date_comparison.go"
+defkit.Validate("expiration date must be later than transition date").
+    WithName("_validateDateOrder").
+    OnlyWhen(defkit.LocalField("date").IsSet()).
+    FailWhen(defkit.And(
+        defkit.LocalField("expiration").IsSet(),
+        defkit.LocalField("expiration").LenGt(0),
+        defkit.LocalField("expiration[0].date").IsSet(),
+        defkit.TimeParse("2006-01-02T15:04:05Z", defkit.LocalField("date")).Gte(
+            defkit.TimeParse("2006-01-02T15:04:05Z", defkit.LocalField("expiration[0].date"))),
+    ))
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+if date != _|_ {
+    _validateDateOrder: {
+        "expiration date must be later than transition date": true
+        if expiration != _|_ && len(expiration) > 0 && expiration[0].date != _|_ && time.Parse("2006-01-02T15:04:05Z", date) >= time.Parse("2006-01-02T15:04:05Z", expiration[0].date) {
+            "expiration date must be later than transition date": false
+        }
+    }
+}
+```
+
+</details>
+
+### String Length Validation with LenOf
+
+Validate the length of concatenated strings:
+
+```go title="length_validation.go"
+name := defkit.String("name").NotEmpty()
+
+defkit.Validate("combined name must be under 64 characters").
+    WithName("_validateNameLength").
+    OnlyWhen(existingResources.Eq(false)).
+    FailWhen(defkit.LenOf(defkit.Plus(
+        defkit.Lit("tenant-"),
+        defkit.Reference("parameter.governance.tenantName"),
+        defkit.Lit("-"),
+        name,
+    )).Gt(63))
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+if parameter.existingResources == false {
+    _validateNameLength: {
+        "combined name must be under 64 characters": true
+        if len("tenant-" + parameter.governance.tenantName + "-" + parameter.name) > 63 {
+            "combined name must be under 64 characters": false
+        }
+    }
+}
+```
+
+</details>
+
+### LocalField Reference Summary
+
+| Method | Generated CUE | Description |
+|:-------|:-------------|:-----------|
+| `LocalField("x").IsSet()` | `x != _\|_` | Field exists |
+| `LocalField("x").NotSet()` | `x == _\|_` | Field absent |
+| `LocalField("x").Eq("v")` | `x == "v"` | Equality |
+| `LocalField("x").Ne("v")` | `x != "v"` | Inequality |
+| `LocalField("x").Matches("pat")` | `x =~ "pat"` | Regex match |
+| `LocalField("x").IsEmpty()` | `len(x) == 0` | Empty collection |
+| `LocalField("x").LenEq(n)` | `len(x) == n` | Length equals |
+| `LocalField("x").LenGt(n)` | `len(x) > n` | Length greater than |
+| `LocalField("a").Gte(LocalField("b"))` | `a >= b` | Field-to-field comparison |
+| `LocalField("a.b").IsSet()` | `a.b != _\|_` | Nested dot-path |
+| `LocalField("a[0].b").IsSet()` | `a[0].b != _\|_` | Array index path |
+
+:::caution
+`LocalField` is for use inside validators attached to `MapParam.Validators()` or `ArrayParam.Validators()`. For template-level conditions (in `SetIf`, `If/EndIf`), use normal parameter references like `defkit.Bool("enabled").IsSet()`.
+:::
+
+## Conditional Parameters
+
+Parameters can change shape -- different fields, different defaults, different optionality -- based on a discriminator value. Use `ConditionalParams` for top-level blocks and `MapParam.ConditionalFields()` for fields inside a struct.
+
+### Top-Level Conditional Blocks
+
+```go title="conditional_params.go"
+existingResources := defkit.Bool("existingResources").Default(false)
+
+comp := defkit.NewComponent("my-component").
+    Params(existingResources, name).
+    ConditionalParams(defkit.ConditionalParams(
+        defkit.WhenParam(existingResources.Eq(false)).Params(
+            defkit.Bool("forceDestroy").Default(false),
+            defkit.Enum("encryption").Default("AES256").Values("AES256", "aws:kms"),
+        ).Validators(
+            defkit.Validate("invalid encryption config").
+                FailWhen(someCondition),
+        ),
+        defkit.WhenParam(existingResources.Eq(true)).Params(
+            defkit.Bool("forceDestroy").Optional(),
+            defkit.Enum("encryption").Optional().Values("AES256", "aws:kms"),
+        ),
+    ))
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+parameter: {
+    existingResources: *false | bool
+    name?: string
+    if existingResources == false {
+        forceDestroy: *false | bool
+        encryption: *"AES256" | "aws:kms"
+        _validateEncryption: { ... }
+    }
+    if existingResources == true {
+        forceDestroy?: bool
+        encryption?: "AES256" | "aws:kms"
+    }
+}
+```
+
+</details>
+
+### Conditional Fields Inside a Struct
+
+Use `MapParam.ConditionalFields()` when the conditional fields are inside an optional struct:
+
+```go title="conditional_fields.go"
+objectLock := defkit.Object("objectLock").Optional().
+    ConditionalFields(
+        defkit.WhenParam(existingResources.Eq(false)).Params(
+            defkit.Int("retentionDays").Optional().Default(45).Min(1),
+            defkit.Enum("retentionMode").Optional().Default("GOVERNANCE").
+                Values("GOVERNANCE", "COMPLIANCE"),
+        ),
+        defkit.WhenParam(existingResources.Eq(true)).Params(
+            defkit.Int("retentionDays").Min(1),
+            defkit.Enum("retentionMode").Values("GOVERNANCE", "COMPLIANCE"),
+        ),
+    )
 ```
 
 ## Arithmetic Expressions: `.Add()` / `.Sub()` / `.Mul()` / `.Div()`

--- a/docs/platform-engineers/defkit/resource-builder.md
+++ b/docs/platform-engineers/defkit/resource-builder.md
@@ -59,6 +59,56 @@ outputs: hpa: {
 }
 ```
 
+### ConditionalStruct -- Conditional Output Block
+
+Emit an entire named sub-struct only when a condition is true, with complex conditional fields inside. This is needed when `If/EndIf` would still emit an empty struct `{}`:
+
+```go title="conditional_struct.go"
+replConfig := defkit.Object("replicationConfiguration")
+
+output := defkit.NewResource("v1alpha1", "S3").
+    Set("spec.region", region).
+    ConditionalStruct(replConfig.IsSet(), "spec.replicationConfiguration", func(b *defkit.OutputStructBuilder) {
+        b.SetIf(defkit.PathExists("parameter.replicationConfiguration.role"),
+            "role",
+            defkit.Reference("parameter.replicationConfiguration.role"))
+        b.SetIf(existingResources.Eq(false),
+            "destinationBucket",
+            defkit.Plus(nameWithPrefix, defkit.Lit("-replica")))
+    })
+```
+
+<details>
+<summary>Generated CUE</summary>
+
+```cue
+output: {
+    apiVersion: "v1alpha1"
+    kind: "S3"
+    spec: {
+        region: parameter.region
+    }
+}
+if parameter["replicationConfiguration"] != _|_ {
+    output: spec: {
+        replicationConfiguration: {
+            if parameter.replicationConfiguration.role != _|_ {
+                role: parameter.replicationConfiguration.role
+            }
+            if parameter.existingResources == false {
+                destinationBucket: "tenant-" + parameter.governance.tenantName + "-" + parameter.name + "-replica"
+            }
+        }
+    }
+}
+```
+
+</details>
+
+:::caution
+Use `ConditionalStruct` instead of `If/EndIf` when the entire struct should be absent from the output when the condition is false. `If/EndIf` guards individual fields but still emits the parent struct as an empty `{}`.
+:::
+
 ## Field Setters
 
 ### `.Set()` / `.SetIf()` / `.SpreadIf()`


### PR DESCRIPTION
### Description of your changes

Enhances existing defkit documentation with expanded examples for:
- **Component definitions** — additional examples for component building patterns
- **Parameter types and validators** — detailed validator usage including array method validators, conditional structures, and constraint examples  
- **Templates and resources** — expanded examples for template patterns and resource collections

This is a clean re-submission of the documentation changes from #1424, rebased on current main.

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.

### Special notes for your reviewer

This PR contains only the 3 files that were modified for validator documentation. The original PR #1424 had rebase issues that pulled in unrelated changes — this branch is clean from upstream main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Go `defkit` docs with validator patterns, array/map constraints, conditional params, and conditional output blocks, with clear Go and generated CUE examples. Adds `OmitWorkloadType()` guidance and clarifies `AutodetectWorkload`.

- **New Features**
  - Components: `OmitWorkloadType()` for custom resources; clarify `AutodetectWorkload`.
  - Strings/regex: `NotEmpty()`, pattern examples; use validators for negative regex.
  - Arrays/Maps: element `NotEmpty`, `OfEnum`, `MinItems`/`MaxItems`; object `Closed()`.
  - Validators: `Validate`/`FailWhen`/`WithName` with `OnlyWhen` guards; attach at component/object/array levels; `LocalField` dot-path and index access; mutual exclusion; length via `LenOf`/`Plus`; dates with `TimeParse`.
  - Conditional params: top-level `ConditionalParams` and nested `MapParam.ConditionalFields()`.
  - Resource builder: `ConditionalStruct` to omit whole sub-structs when false; `SetIf` inside the block.

<sup>Written for commit 73481a34e2579574fc985b6a293224c62b281543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

