### PR TITLE
docs: add examples for merging values from ConfigMap and Secret in he…

### DIFF
--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -629,6 +629,65 @@ spec:
           version: "1.0.0"
 ```
 
+Merge values from a ConfigMap and a Secret, with inline values taking precedence over both:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: podinfo-base
+  namespace: default
+data:
+  values.yaml: |
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: podinfo-overrides
+  namespace: default
+stringData:
+  values.yaml: |
+    resources:
+      limits:
+        memory: 512Mi
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: podinfo-layered
+spec:
+  components:
+    - name: podinfo
+      type: helmchart
+      properties:
+        chart:
+          source: podinfo
+          repoURL: https://stefanprodan.github.io/podinfo
+          version: "6.11.1"
+        release:
+          name: podinfo
+          namespace: default
+        values:
+          # Inline values win over everything in valuesFrom.
+          replicaCount: 5
+        valuesFrom:
+          - kind: ConfigMap
+            name: podinfo-base
+          - kind: Secret
+            name: podinfo-overrides
+            # key defaults to "values.yaml"; optional defaults to false.
+        options:
+          createNamespace: true
+          skipTests: true
+```
+
+The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memory: 512Mi` (Secret overlay wins over the ConfigMap on the conflict), and `resources.limits.cpu: 100m` (preserved from the ConfigMap — the Secret didn't touch it).
+
 ### Specification (helmchart)
 
 
@@ -636,7 +695,8 @@ spec:
  ---- | ----------- | ---- | -------- | ------- 
  chart | Chart source configuration | [chart](#chart-helmchart) | true |  
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
- values | Inline values (highest priority) | map[string]interface{} | false |  
+ values | Inline values merged with the highest priority; override everything in valuesFrom. | map[string]interface{} | false |  
+ valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. Sources are read once per reconcile — editing a referenced ConfigMap/Secret does NOT trigger a new reconcile, so bump the Application spec to roll out new values. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
 
@@ -647,6 +707,17 @@ spec:
  source | Chart location - automatically detected based on format (OCI, Direct URL, Repo chart) | string | true |  
  repoURL | Repository URL for repository-based charts | string | false |  
  version | Version/tag for repository and OCI charts (ignored for direct URLs) | string | false | "latest" 
+
+
+#### valuesFrom (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ kind | Source kind. Only `Secret` and `ConfigMap` are supported; `OCIRepository` is reserved for a future release. | "Secret" or "ConfigMap" | true |  
+ name | Name of the Secret or ConfigMap. | string | true |  
+ namespace | Namespace of the Secret or ConfigMap. Defaults to the release namespace. An explicit value must match either the release namespace or the Application's own namespace — other namespaces are rejected to prevent cross-tenant reads via the controller's cluster-wide RBAC. | string | false |  
+ key | Key inside `.data` whose value is parsed as YAML. | string | false | "values.yaml" 
+ optional | If true, a missing Secret/ConfigMap or missing key is skipped silently. Parse errors and permission errors still fail the render. | bool | false | false 
 
 
 #### release (helmchart)


### PR DESCRIPTION
### Description of your changes

Documents the newly-supported `valuesFrom` field on the `helmchart` component (implementation: kubevela/kubevela#7099) in the end-user component reference.

Adds to `docs/end-user/components/references.md`:

1. **A three-layer merge example** under the existing `helmchart` section showing `ConfigMap` + `Secret` + inline `values` together, with a paragraph explaining what the rendered chart actually sees after the merge (inline wins overall, later `valuesFrom` beats earlier on conflict, and orthogonal keys from the earlier source are preserved).
2. **The `valuesFrom` row in the top-level spec table**, with the precedence rules and the "editing sources doesn't auto-reconcile" caveat inline so readers see it on the first pass.
3. **A new `#### valuesFrom (helmchart)` sub-table** describing every field (`kind`, `name`, `namespace`, `key`, `optional`) with defaults and the semantics that matter: `"values.yaml"` as the default key, cross-namespace rejection, and the scope of `optional: true` (skips missing resource/key only — parse and permission errors still fail the render).
4. **Updates the `values` row** so its description mentions that inline values override everything in `valuesFrom` rather than just calling them "highest priority" without context.

The field descriptions are intentionally kept in lock-step with the `+usage` strings on the CUE schema in the implementation PR so future `make manifests` regeneration doesn't create drift between code and docs.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page. — N/A, this edits an existing reference page only.
- [x] Run `yarn start` to ensure the changes has taken effect.

### Special notes for your reviewer

- **Pairs with kubevela/kubevela#7099.** That PR ships the `valuesFrom` implementation for `ConfigMap` and `Secret` sources; this PR documents the user-visible surface. `OCIRepository` is intentionally omitted from both — it's tracked as a follow-up that will land together with OCI chart-source auth.
- **The cross-namespace rule is documented explicitly in the `namespace` row** because the failure surface for users who hit it is a rejected reconcile rather than a fallback — they need to know up front that shared config across namespaces needs to be replicated, not referenced.
- **The "external CM/Secret edits do not auto-reconcile" caveat is repeated in the `valuesFrom` top-level description** rather than only mentioned in the sub-table. This is the single question users hit first after the feature works for them, and keeping the answer where they'll look first avoids a doc-bug cycle.
- The merge-rule phrasing ("deep-merges map keys; arrays are replaced (not concatenated); null is preserved") matches `chartutil.CoalesceTables` semantics used by the implementation, which diverges slightly from `helm CLI --values` (that path uses `CoalesceValues`). Worth a reviewer eyeball in case wording needs to be loosened for users who expect array concatenation.
