### PR TITLE
docs: document helmchart auth for private OCI and HTTPS registries

### DIFF
--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -606,7 +606,7 @@ spec:
 
 ## Helmchart
 
-> **Note:** There is a known limitation with pre-delete and post-delete hook functionality that will be addressed in later releases. Currently, only public chart repositories are supported — authentication for private repositories is on the roadmap.
+> **Note:** There is a known limitation with pre-delete and post-delete hook functionality that will be addressed in later releases.
 
 ### Description
 
@@ -686,7 +686,149 @@ spec:
           skipTests: true
 ```
 
-The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memory: 512Mi` (Secret overlay wins over the ConfigMap on the conflict), and `resources.limits.cpu: 100m` (preserved from the ConfigMap — the Secret didn't touch it).
+The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memory: 512Mi` (Secret overlay wins over the ConfigMap on the conflict), and `resources.limits.cpu: 100m` (preserved from the ConfigMap; the Secret didn't touch it).
+
+#### Authenticating with private chart registries
+
+KubeVela supports private Helm repositories and OCI registries through a `secretRef` on the `chart` block. The Secret is read by the vela-core controller, so it must live in the vela-core namespace (`vela-system` by default) unless the `namespace` field overrides it.
+
+**OCI private registry (Docker Hub, GHCR, ECR, etc.)**
+
+Create a `kubernetes.io/basic-auth` Secret with your registry username and password:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-creds
+  namespace: vela-system
+type: kubernetes.io/basic-auth
+stringData:
+  username: my-github-username
+  password: ghp_xxxxxxxxxxxxxxxxxxxx   # GitHub PAT with read:packages scope
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: private-oci-chart
+spec:
+  components:
+    - name: my-app
+      type: helmchart
+      properties:
+        chart:
+          source: oci://ghcr.io/my-org/charts/my-app
+          version: "2.1.0"
+          auth:
+            secretRef:
+              name: ghcr-creds
+              namespace: vela-system
+        release:
+          name: my-app
+          namespace: default
+```
+
+A `kubernetes.io/dockerconfigjson` Secret (e.g. created with `kubectl create secret docker-registry`) also works. KubeVela extracts the credentials from the `.dockerconfigjson` key automatically.
+
+**HTTPS Helm repository with basic auth**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartmuseum-creds
+  namespace: vela-system
+type: kubernetes.io/basic-auth
+stringData:
+  username: helm-user
+  password: s3cr3t
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: private-https-chart
+spec:
+  components:
+    - name: my-app
+      type: helmchart
+      properties:
+        chart:
+          source: my-app
+          repoURL: https://charts.example.com
+          version: "1.0.0"
+          auth:
+            secretRef:
+              name: chartmuseum-creds
+              namespace: vela-system
+        release:
+          name: my-app
+          namespace: default
+```
+
+**HTTPS Helm repository with Bearer token**
+
+Some private repositories (Nexus, Artifactory, custom proxies) use Bearer token auth instead of Basic. Use an `Opaque` Secret with a `token` key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nexus-token
+  namespace: vela-system
+type: Opaque
+stringData:
+  token: "my-bearer-token"
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: bearer-token-chart
+spec:
+  components:
+    - name: my-app
+      type: helmchart
+      properties:
+        chart:
+          source: my-app
+          repoURL: https://nexus.example.com/repository/helm-hosted
+          version: "1.0.0"
+          auth:
+            secretRef:
+              name: nexus-token
+              namespace: vela-system
+        release:
+          name: my-app
+          namespace: default
+```
+
+**Direct .tgz URL with auth**
+
+The `source` field also accepts a direct `.tgz` URL. Auth works the same way:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: tgz-url-chart
+spec:
+  components:
+    - name: my-app
+      type: helmchart
+      properties:
+        chart:
+          source: https://artifacts.example.com/charts/my-app-1.0.0.tgz
+          auth:
+            secretRef:
+              name: chartmuseum-creds
+              namespace: vela-system
+        release:
+          name: my-app
+          namespace: default
+```
+
+**Rotating credentials**
+
+When you rotate the Secret, the chart cache key changes automatically (it incorporates a hash of the Secret data). The next reconcile fetches a fresh copy of the chart with the new credentials. No Application spec bump is required.
 
 ### Specification (helmchart)
 
@@ -707,6 +849,31 @@ The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memor
  source | Chart location - automatically detected based on format (OCI, Direct URL, Repo chart) | string | true |  
  repoURL | Repository URL for repository-based charts | string | false |  
  version | Version/tag for repository and OCI charts (ignored for direct URLs) | string | false | "latest" 
+ auth | Credentials for private chart sources | [auth](#auth-helmchart) | false |  
+
+
+#### auth (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ secretRef | Reference to the Secret holding credentials | [secretRef](#secretref-helmchart) | true |  
+
+
+#### secretRef (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ name | Name of the Secret | string | true |  
+ namespace | Namespace of the Secret. Defaults to the Application namespace. The vela-core controller must have RBAC access to read Secrets in this namespace. | string | false |  
+
+Supported Secret types:
+
+| Secret type | Credentials read | Use case |
+|---|---|---|
+| `kubernetes.io/basic-auth` | `username` + `password` keys | HTTPS Helm repo, OCI registry username/password |
+| `kubernetes.io/dockerconfigjson` | `.dockerconfigjson` key (standard Docker config) | OCI registry with Docker-format credentials |
+| `Opaque` with `username`/`password` | `username` + `password` keys | HTTPS Helm repo, OCI registry |
+| `Opaque` with `token` | `token` key | Bearer token auth (Nexus, Artifactory, custom proxies) |
 
 
 #### valuesFrom (helmchart)
@@ -738,7 +905,7 @@ The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memor
  timeout | Rendering timeout | string | false | "5m" 
  maxHistory | Revisions to keep | int | false | 10 
  atomic | Rollback on failure | bool | false | false 
- wait | Wait for resources | bool | false | false 
+ wait | Wait for resources to become ready before marking the workflow step complete | bool | false | true 
  force | Force resource updates | bool | false | false 
  recreatePods | Recreate pods on upgrade | bool | false | false 
  cleanupOnFail | Cleanup on failure | bool | false | false 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -743,7 +743,7 @@ The same `auth` block works for HTTPS repos (`source` + `repoURL`) and direct `.
  chart | Chart source configuration | [chart](#chart-helmchart) | true |  
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
  values | Inline values merged with the highest priority; override everything in valuesFrom. | map[string]interface{} | false |  
- valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
+ valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. On every reconcile the controller computes a content fingerprint over all referenced sources; an external edit to a referenced ConfigMap or Secret triggers a `helm upgrade` automatically on the next reconcile (default resync ~5 min). Sources are read from the control-plane cluster regardless of where the chart is deployed. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
  healthStatus | Criteria for declaring the component healthy. Each entry names a resource kind and a condition to check. When all entries pass, the workflow step is marked complete. If omitted, KubeVela uses its default readiness heuristic. | [[]healthStatus](#healthstatus-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
@@ -770,7 +770,7 @@ The same `auth` block works for HTTPS repos (`source` + `repoURL`) and direct `.
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
  name | Name of the Secret | string | true |  
- namespace | Namespace of the Secret. Defaults to the Application namespace. The vela-core controller must have RBAC access to read Secrets in this namespace. | string | false |  
+ namespace | Namespace of the Secret. Defaults to the release namespace, which itself defaults to the Application namespace when `release.namespace` is unset. Must be either the release namespace or the Application namespace; cross-namespace references are rejected. | string | false |  
 
 Supported Secret types:
 
@@ -778,8 +778,13 @@ Supported Secret types:
 |---|---|---|
 | `kubernetes.io/basic-auth` | `username` + `password` keys | HTTPS Helm repo, OCI registry username/password |
 | `kubernetes.io/dockerconfigjson` | `.dockerconfigjson` key (standard Docker config) | OCI registry with Docker-format credentials |
+| `kubernetes.io/tls` | `tls.crt`, `tls.key`, optional `ca.crt` | Mutual TLS client authentication |
 | `Opaque` with `username`/`password` | `username` + `password` keys | HTTPS Helm repo, OCI registry |
-| `Opaque` with `token` | `token` key | Bearer token auth (Nexus, Artifactory, custom proxies) |
+| `Opaque` with `token` | `token` key | Bearer token auth (HTTPS Helm repos and direct `.tgz` URLs only; see note below) |
+
+An `Opaque` Secret can also include these optional TLS fields: `caFile` (custom CA bundle), `certFile` + `keyFile` (client certificate), `insecureSkipTLS` (skip server certificate verification), and `insecurePlainHTTP` (OCI sources only; use plain HTTP instead of HTTPS).
+
+> **Note on Bearer tokens:** Bearer tokens work on HTTPS Helm repositories and direct `.tgz` URLs only. They must not be used with OCI registries (OCI performs its own Basic-to-Bearer exchange per the Distribution Spec). They must not be combined with `insecureSkipTLS` (RFC 6750 requires TLS) and must not appear alongside `username`/`password` keys in the same Secret.
 
 
 #### valuesFrom (helmchart)
@@ -789,7 +794,7 @@ Supported Secret types:
  kind | Source kind. Only `Secret` and `ConfigMap` are supported. `OCIRepository` is not yet supported. | "Secret" or "ConfigMap" | true |  
  name | Name of the Secret or ConfigMap. | string | true |  
  namespace | Namespace of the Secret or ConfigMap. Defaults to the release namespace. An explicit value must match either the release namespace or the Application's own namespace; other namespaces are rejected to prevent cross-tenant reads via the controller's cluster-wide RBAC. | string | false |  
- key | Key inside `.data` whose value is parsed as YAML. | string | false | "values.yaml" 
+ key | Key inside `.data` whose value is parsed as YAML. Only `.data` is read; `ConfigMap.binaryData` is rejected. | string | false | "values.yaml" 
  optional | If true, a missing Secret/ConfigMap or missing key is skipped silently. Parse errors and permission errors still fail the render. | bool | false | false 
 
 
@@ -803,7 +808,9 @@ Supported Secret types:
 
 #### healthStatus (helmchart)
 
-Each entry in the `healthStatus` array names one Kubernetes resource and the condition that must be `True` for that resource to be considered healthy. All entries must pass for the component to be marked healthy.
+Each entry in the `healthStatus` array names one Kubernetes resource and the condition that must be `True` for that resource to be considered healthy. All entries must pass for the component to be marked healthy. If omitted, the component is considered healthy immediately after dispatch.
+
+Only use resource kinds that expose `.status.conditions` (Deployment, StatefulSet, Job, Pod, Node, and most CRD-based resources). Resources that do not expose conditions such as Service or ConfigMap will always evaluate to unhealthy.
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
@@ -823,8 +830,8 @@ Each entry in the `healthStatus` array names one Kubernetes resource and the con
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- type | Condition type to check. Accepts any Kubernetes condition string, e.g. `Ready`, `Available`, `Progressing`. | string | true |  
- status | Expected condition status | "True" or "False" | false | "True" 
+ type | Condition type to check. Accepts any Kubernetes condition string. Common values: `Available` and `Progressing` for Deployments; `Available` for StatefulSets; `Ready` for Pods; `Complete` or `Failed` for Jobs. | string | true |  
+ status | Expected condition status. Use `"False"` for conditions like `Progressing` where the healthy state is `False`. | "True" or "False" | false | "True" 
 
 
 #### options (helmchart)
@@ -838,7 +845,8 @@ Each entry in the `healthStatus` array names one Kubernetes resource and the con
  timeout | Rendering timeout | string | false | "5m" 
  maxHistory | Revisions to keep | int | false | 10 
  atomic | Rollback on failure | bool | false | false 
- wait | Wait for resources to become ready before marking the workflow step complete | bool | false | true 
+ wait | Wait for resources to become ready before marking the workflow step complete | bool | false | false 
+ waitTimeout | How long to wait for resources when `wait` is true | string | false | "10m" 
  force | Force resource updates | bool | false | false 
  recreatePods | Recreate pods on upgrade | bool | false | false 
  cleanupOnFail | Cleanup on failure | bool | false | false 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -690,27 +690,30 @@ The rendered chart sees `replicaCount: 5` (from inline), `resources.limits.memor
 
 #### Authenticating with private chart registries
 
-KubeVela supports private Helm repositories and OCI registries through a `secretRef` on the `chart` block. The Secret is read by the vela-core controller, so it must live in the vela-core namespace (`vela-system` by default) unless the `namespace` field overrides it.
+Add `chart.auth.secretRef` to point at a Secret in the vela-core namespace (`vela-system` by default). The Secret type controls how credentials are extracted:
 
-**OCI private registry (Docker Hub, GHCR, ECR, etc.)**
-
-Create a `kubernetes.io/basic-auth` Secret with your registry username and password:
+| Secret type | Keys read | Use case |
+|---|---|---|
+| `kubernetes.io/basic-auth` | `username`, `password` | HTTPS Helm repo, OCI registry |
+| `kubernetes.io/dockerconfigjson` | `.dockerconfigjson` | OCI registry (Docker-format config) |
+| `Opaque` with `username`/`password` | `username`, `password` | HTTPS Helm repo, OCI registry |
+| `Opaque` with `token` | `token` | Bearer token auth (Nexus, Artifactory) |
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ghcr-creds
+  name: registry-creds
   namespace: vela-system
 type: kubernetes.io/basic-auth
 stringData:
-  username: my-github-username
-  password: ghp_xxxxxxxxxxxxxxxxxxxx   # GitHub PAT with read:packages scope
+  username: my-username
+  password: my-password-or-token
 ---
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: private-oci-chart
+  name: private-chart
 spec:
   components:
     - name: my-app
@@ -718,117 +721,17 @@ spec:
       properties:
         chart:
           source: oci://ghcr.io/my-org/charts/my-app
-          version: "2.1.0"
-          auth:
-            secretRef:
-              name: ghcr-creds
-              namespace: vela-system
-        release:
-          name: my-app
-          namespace: default
-```
-
-A `kubernetes.io/dockerconfigjson` Secret (e.g. created with `kubectl create secret docker-registry`) also works. KubeVela extracts the credentials from the `.dockerconfigjson` key automatically.
-
-**HTTPS Helm repository with basic auth**
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: chartmuseum-creds
-  namespace: vela-system
-type: kubernetes.io/basic-auth
-stringData:
-  username: helm-user
-  password: s3cr3t
----
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: private-https-chart
-spec:
-  components:
-    - name: my-app
-      type: helmchart
-      properties:
-        chart:
-          source: my-app
-          repoURL: https://charts.example.com
           version: "1.0.0"
           auth:
             secretRef:
-              name: chartmuseum-creds
+              name: registry-creds
               namespace: vela-system
         release:
           name: my-app
           namespace: default
 ```
 
-**HTTPS Helm repository with Bearer token**
-
-Some private repositories (Nexus, Artifactory, custom proxies) use Bearer token auth instead of Basic. Use an `Opaque` Secret with a `token` key:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: nexus-token
-  namespace: vela-system
-type: Opaque
-stringData:
-  token: "my-bearer-token"
----
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: bearer-token-chart
-spec:
-  components:
-    - name: my-app
-      type: helmchart
-      properties:
-        chart:
-          source: my-app
-          repoURL: https://nexus.example.com/repository/helm-hosted
-          version: "1.0.0"
-          auth:
-            secretRef:
-              name: nexus-token
-              namespace: vela-system
-        release:
-          name: my-app
-          namespace: default
-```
-
-**Direct .tgz URL with auth**
-
-The `source` field also accepts a direct `.tgz` URL. Auth works the same way:
-
-```yaml
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: tgz-url-chart
-spec:
-  components:
-    - name: my-app
-      type: helmchart
-      properties:
-        chart:
-          source: https://artifacts.example.com/charts/my-app-1.0.0.tgz
-          auth:
-            secretRef:
-              name: chartmuseum-creds
-              namespace: vela-system
-        release:
-          name: my-app
-          namespace: default
-```
-
-**Rotating credentials**
-
-When you rotate the Secret, the chart cache key changes automatically (it incorporates a hash of the Secret data). The next reconcile fetches a fresh copy of the chart with the new credentials. No Application spec bump is required.
+The same `auth` block works for HTTPS repos (`source` + `repoURL`) and direct `.tgz` URLs. When you rotate the Secret, the cache key updates automatically and the next reconcile pulls a fresh copy of the chart.
 
 ### Specification (helmchart)
 
@@ -838,7 +741,7 @@ When you rotate the Secret, the chart cache key changes automatically (it incorp
  chart | Chart source configuration | [chart](#chart-helmchart) | true |  
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
  values | Inline values merged with the highest priority; override everything in valuesFrom. | map[string]interface{} | false |  
- valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. Sources are read once per reconcile — editing a referenced ConfigMap/Secret does NOT trigger a new reconcile, so bump the Application spec to roll out new values. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
+ valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. Sources are read once per reconcile. Editing a referenced ConfigMap/Secret does NOT trigger a new reconcile, so bump the Application spec to roll out new values. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
 
@@ -882,7 +785,7 @@ Supported Secret types:
  ---- | ----------- | ---- | -------- | ------- 
  kind | Source kind. Only `Secret` and `ConfigMap` are supported; `OCIRepository` is reserved for a future release. | "Secret" or "ConfigMap" | true |  
  name | Name of the Secret or ConfigMap. | string | true |  
- namespace | Namespace of the Secret or ConfigMap. Defaults to the release namespace. An explicit value must match either the release namespace or the Application's own namespace — other namespaces are rejected to prevent cross-tenant reads via the controller's cluster-wide RBAC. | string | false |  
+ namespace | Namespace of the Secret or ConfigMap. Defaults to the release namespace. An explicit value must match either the release namespace or the Application's own namespace; other namespaces are rejected to prevent cross-tenant reads via the controller's cluster-wide RBAC. | string | false |  
  key | Key inside `.data` whose value is parsed as YAML. | string | false | "values.yaml" 
  optional | If true, a missing Secret/ConfigMap or missing key is skipped silently. Parse errors and permission errors still fail the render. | bool | false | false 
 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -606,11 +606,11 @@ spec:
 
 ## Helmchart
 
-> **Note:** There is a known limitation with pre-delete and post-delete hook functionality that will be addressed in later releases.
+> **Note:** `pre-delete` and `post-delete` Helm hooks do not execute. KubeVela's GC deletes resources directly via the Kubernetes API and never calls `helm uninstall`, so delete-phase hooks are bypassed entirely. Install and upgrade hooks (`pre-install`, `post-install`, `pre-upgrade`, `post-upgrade`) work correctly.
 
 ### Description
 
-Deploy Helm charts natively in KubeVela
+Render and deploy Helm charts directly using the Helm Go SDK, without requiring the FluxCD addon. Charts can be sourced from HTTP(S) repositories, OCI registries, or direct `.tgz` URLs, and integrate with KubeVela's standard features including multi-cluster placement, workflow steps, and Application revision tracking.
 
 ### Examples (helmchart)
 
@@ -628,6 +628,8 @@ spec:
           source: oci://ghcr.io/org/charts/app
           version: "1.0.0"
 ```
+
+After the Application is reconciled you will see a ConfigMap named `{releaseName}-helm-release` in the release namespace. KubeVela creates this as its stable primary output to track release metadata. It is managed by the controller and should not be edited or deleted manually.
 
 Merge values from a ConfigMap and a Secret, with inline values taking precedence over both:
 
@@ -742,6 +744,7 @@ The same `auth` block works for HTTPS repos (`source` + `repoURL`) and direct `.
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
  values | Inline values merged with the highest priority; override everything in valuesFrom. | map[string]interface{} | false |  
  valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. Sources are read once per reconcile. Editing a referenced ConfigMap/Secret does NOT trigger a new reconcile, so bump the Application spec to roll out new values. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
+ healthStatus | Criteria for declaring the component healthy. Each entry names a resource kind and a condition to check. When all entries pass, the workflow step is marked complete. If omitted, KubeVela uses its default readiness heuristic. | [[]healthStatus](#healthstatus-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
 
@@ -783,7 +786,7 @@ Supported Secret types:
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- kind | Source kind. Only `Secret` and `ConfigMap` are supported; `OCIRepository` is reserved for a future release. | "Secret" or "ConfigMap" | true |  
+ kind | Source kind. Only `Secret` and `ConfigMap` are supported. `OCIRepository` is not yet supported. | "Secret" or "ConfigMap" | true |  
  name | Name of the Secret or ConfigMap. | string | true |  
  namespace | Namespace of the Secret or ConfigMap. Defaults to the release namespace. An explicit value must match either the release namespace or the Application's own namespace; other namespaces are rejected to prevent cross-tenant reads via the controller's cluster-wide RBAC. | string | false |  
  key | Key inside `.data` whose value is parsed as YAML. | string | false | "values.yaml" 
@@ -798,10 +801,37 @@ Supported Secret types:
  namespace | Target namespace (defaults to Application namespace) | string | false |  
 
 
+#### healthStatus (helmchart)
+
+Each entry in the `healthStatus` array names one Kubernetes resource and the condition that must be `True` for that resource to be considered healthy. All entries must pass for the component to be marked healthy.
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ resource | Resource to check | [resource](#resource-helmchart) | true |  
+ condition | Condition to evaluate | [condition](#condition-helmchart) | true |  
+
+
+##### resource (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ kind | Kubernetes resource kind (e.g. `Deployment`, `StatefulSet`) | string | true |  
+ name | Resource name. If omitted, any resource of the matching kind satisfies the check. | string | false |  
+
+
+##### condition (helmchart)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ type | Condition type to check. Accepts any Kubernetes condition string, e.g. `Ready`, `Available`, `Progressing`. | string | true |  
+ status | Expected condition status | "True" or "False" | false | "True" 
+
+
 #### options (helmchart)
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
+ includeCRDs | Include CRD resources from the chart | bool | false | true 
  skipTests | Skip test resources | bool | false | true 
  skipHooks | Skip hook resources | bool | false | false 
  createNamespace | Create namespace if it doesn't exist | bool | false | true 
@@ -812,6 +842,75 @@ Supported Secret types:
  force | Force resource updates | bool | false | false 
  recreatePods | Recreate pods on upgrade | bool | false | false 
  cleanupOnFail | Cleanup on failure | bool | false | false 
+ cache | Chart cache tuning | [cache](#cache-helmchart) | false |  
+
+
+#### cache (helmchart)
+
+The chart cache is in-memory and scoped to the vela-core controller pod. It resets on controller restart. By default each Application component gets its own cache namespace; set `key` to share a cache entry across components that use the same chart.
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ key | Cache key prefix. Defaults to `{appName}-{componentName}`. Set a shared value to reuse a cached chart across multiple components. | string | false |  
+ ttl | TTL for all versions, overriding the automatic immutable/mutable detection. Set to `"0"` to disable caching entirely. | string | false |  
+ immutableTTL | TTL for pinned (immutable) versions such as `1.2.3` or `v2.0.0`. | string | false | "24h" 
+ mutableTTL | TTL for floating versions such as `latest`, `dev`, or `-SNAPSHOT`. | string | false | "5m" 
+
+
+### Known limitations (helmchart)
+
+**Delete hooks do not fire**
+
+`pre-delete` and `post-delete` Helm hooks are never executed. KubeVela's GC deletes resources individually via the Kubernetes API without calling `helm uninstall`. Charts that rely on cleanup Jobs (database migrations, deregistration webhooks) will not run them on Application deletion. As a workaround, run those Jobs manually before deleting the Application.
+
+**CRDs from the `crds/` directory are not cleaned up on deletion**
+
+Helm never deletes CRDs it installed from a chart's `crds/` directory (by design, to prevent data loss). When you delete a helmchart Application, those CRDs are left behind. Affected charts include kube-prometheus-stack, ARC controller, and others that bundle CRDs in the `crds/` directory rather than in chart templates. CRDs installed via chart templates (Istio, cert-manager) are tracked normally and are cleaned up.
+
+**Chart cache is in-memory only**
+
+The chart cache lives in the vela-core controller pod's memory. A controller restart clears it, causing the next reconcile for each component to re-fetch its chart. This produces a short burst of chart downloads after a controller upgrade or pod eviction.
+
+**Editing a referenced ConfigMap or Secret does not trigger reconcile**
+
+When using `valuesFrom`, editing the referenced ConfigMap or Secret does not automatically re-render the chart. Touch any field under the Application's `.spec` (adding or changing an annotation works) to force a new reconcile.
+
+**Migrating from the FluxCD addon**
+
+The FluxCD `helm` component type uses a flat property structure. The native `helmchart` type restructures these under `chart`, `release`, and `values`:
+
+```yaml
+# Before (FluxCD addon)
+- name: database
+  type: helm
+  properties:
+    repoType: helm
+    url: https://charts.bitnami.com/bitnami
+    chart: postgresql
+    version: "12.1.0"
+    targetNamespace: default
+    releaseName: postgres
+    values:
+      auth:
+        database: myapp
+
+# After (native helmchart)
+- name: database
+  type: helmchart
+  properties:
+    chart:
+      source: postgresql
+      repoURL: https://charts.bitnami.com/bitnami
+      version: "12.1.0"
+    release:
+      name: postgres
+      namespace: default
+    values:
+      auth:
+        database: myapp
+```
+
+If an existing vanilla Helm release is already running in the cluster, the controller adopts it automatically on first reconcile with zero pod disruption.
 
 
 ## K8s-Objects

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -838,18 +838,16 @@ Only use resource kinds that expose `.status.conditions` (Deployment, StatefulSe
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- includeCRDs | Include CRD resources from the chart | bool | false | true 
  skipTests | Skip test resources | bool | false | true 
  skipHooks | Skip hook resources | bool | false | false 
  createNamespace | Create namespace if it doesn't exist | bool | false | true 
- timeout | Rendering timeout | string | false | "5m" 
- maxHistory | Revisions to keep | int | false | 10 
+ timeout | Rendering and wait timeout | string | false | "5m" 
+ maxHistory | Revisions to keep. Takes effect on upgrade; ignored on first install. | int | false | 10 
  atomic | Rollback on failure | bool | false | false 
  wait | Wait for resources to become ready before marking the workflow step complete | bool | false | false 
- waitTimeout | How long to wait for resources when `wait` is true | string | false | "10m" 
- force | Force resource updates | bool | false | false 
- recreatePods | Recreate pods on upgrade | bool | false | false 
- cleanupOnFail | Cleanup on failure | bool | false | false 
+ force | Force resource updates. Takes effect on upgrade; ignored on first install. | bool | false | false 
+ recreatePods | Recreate pods on upgrade. Ignored on first install. | bool | false | false 
+ cleanupOnFail | Cleanup on failure. Takes effect on upgrade; ignored on first install. | bool | false | false 
  cache | Chart cache tuning | [cache](#cache-helmchart) | false |  
 
 

--- a/docs/end-user/components/references.md
+++ b/docs/end-user/components/references.md
@@ -743,7 +743,7 @@ The same `auth` block works for HTTPS repos (`source` + `repoURL`) and direct `.
  chart | Chart source configuration | [chart](#chart-helmchart) | true |  
  release | Release configuration (optional - uses context defaults) | [release](#release-helmchart) | false |  
  values | Inline values merged with the highest priority; override everything in valuesFrom. | map[string]interface{} | false |  
- valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. Sources are read once per reconcile. Editing a referenced ConfigMap/Secret does NOT trigger a new reconcile, so bump the Application spec to roll out new values. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
+ valuesFrom | Additional values sources merged in array order. Later entries override earlier ones on conflict, and inline `values` override everything in valuesFrom. Deep-merges map keys; arrays are replaced (not concatenated); null is preserved. | [[]valuesFrom](#valuesfrom-helmchart) | false |  
  healthStatus | Criteria for declaring the component healthy. Each entry names a resource kind and a condition to check. When all entries pass, the workflow step is marked complete. If omitted, KubeVela uses its default readiness heuristic. | [[]healthStatus](#healthstatus-helmchart) | false |  
  options | Rendering options | [options](#options-helmchart) | false |  
 
@@ -865,52 +865,11 @@ The chart cache is in-memory and scoped to the vela-core controller pod. It rese
 
 **CRDs from the `crds/` directory are not cleaned up on deletion**
 
-Helm never deletes CRDs it installed from a chart's `crds/` directory (by design, to prevent data loss). When you delete a helmchart Application, those CRDs are left behind. Affected charts include kube-prometheus-stack, ARC controller, and others that bundle CRDs in the `crds/` directory rather than in chart templates. CRDs installed via chart templates (Istio, cert-manager) are tracked normally and are cleaned up.
+Helm never deletes CRDs installed from a chart's `crds/` directory. This is Helm's own design to prevent data loss. When you delete a helmchart Application, any CRDs that came from the `crds/` directory are left behind and must be cleaned up manually. CRDs that a chart ships as regular template resources are tracked by KubeVela and deleted with the Application.
 
 **Chart cache is in-memory only**
 
 The chart cache lives in the vela-core controller pod's memory. A controller restart clears it, causing the next reconcile for each component to re-fetch its chart. This produces a short burst of chart downloads after a controller upgrade or pod eviction.
-
-**Editing a referenced ConfigMap or Secret does not trigger reconcile**
-
-When using `valuesFrom`, editing the referenced ConfigMap or Secret does not automatically re-render the chart. Touch any field under the Application's `.spec` (adding or changing an annotation works) to force a new reconcile.
-
-**Migrating from the FluxCD addon**
-
-The FluxCD `helm` component type uses a flat property structure. The native `helmchart` type restructures these under `chart`, `release`, and `values`:
-
-```yaml
-# Before (FluxCD addon)
-- name: database
-  type: helm
-  properties:
-    repoType: helm
-    url: https://charts.bitnami.com/bitnami
-    chart: postgresql
-    version: "12.1.0"
-    targetNamespace: default
-    releaseName: postgres
-    values:
-      auth:
-        database: myapp
-
-# After (native helmchart)
-- name: database
-  type: helmchart
-  properties:
-    chart:
-      source: postgresql
-      repoURL: https://charts.bitnami.com/bitnami
-      version: "12.1.0"
-    release:
-      name: postgres
-      namespace: default
-    values:
-      auth:
-        database: myapp
-```
-
-If an existing vanilla Helm release is already running in the cluster, the controller adopts it automatically on first reconcile with zero pod disruption.
 
 
 ## K8s-Objects


### PR DESCRIPTION
## What this PR does

The \`helmchart\` component now supports authenticating against private chart registries via \`chart.auth.secretRef\` (added in kubevela/kubevela#7148). The docs still carried a note saying authentication was on the roadmap. This PR removes that note and fills in the actual usage documentation.

## Changes

- Remove the outdated "only public chart repositories are supported" notice from the Helmchart section
- Add a new "Authenticating with private chart registries" subsection under Examples with runnable manifests for:
  - OCI private registry using \`kubernetes.io/basic-auth\` (GHCR, Docker Hub, ECR, etc.)
  - OCI private registry using \`kubernetes.io/dockerconfigjson\`
  - HTTPS Helm repository with basic auth
  - HTTPS Helm repository with Bearer token (Nexus, Artifactory, custom proxies)
  - Direct \`.tgz\` URL with auth
  - Credential rotation behavior
- Add \`auth\` field to the \`chart\` spec table with a link to the new subsection
- Add \`auth (helmchart)\` and \`secretRef (helmchart)\` spec subsections
- Add a supported Secret types matrix documenting which keys are read for each Secret type
- Fix the \`wait\` option default: the schema default is \`true\`, not \`false\`

## Related

kubevela/kubevela#7148

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `helmchart` docs to cover private registry auth, health checks, caching, and known limitations. Adds `chart.auth.secretRef`, `options.waitTimeout`, release metadata notes, and `valuesFrom` auto-reconcile.

- **New Features**
  - Document `chart.auth.secretRef` for private sources with one example and a variants table; expand Secret types to include `kubernetes.io/tls` and note optional TLS fields (`caFile`, `certFile`, `keyFile`, `insecureSkipTLS`, `insecurePlainHTTP`), namespace defaults/constraints, rotation behavior, and that bearer tokens are HTTPS-only (not OCI).
  - Add spec docs for `healthStatus`, `options.cache`, and `options.waitTimeout`; note the `{releaseName}-helm-release` ConfigMap, include a FluxCD migration snippet, and add Known Limitations (delete hooks disabled, CRDs from `crds/` not cleaned up, cache is in-memory).
  - Update `valuesFrom`: fingerprint-based auto-reconcile on external changes, restrict kinds to `Secret`/`ConfigMap`, and reject `ConfigMap.binaryData`.

- **Bug Fixes**
  - Correct defaults and wording: `release.wait` default is false; `secretRef.namespace` defaults to the release namespace; clarify `OCIRepository` is not yet supported.
  - Fix the `options` table: remove no-op fields and mark upgrade-only flags.

<sup>Written for commit e8a36b3f8f08a87db7ebf545b714399db027aa84. Summary will update on new commits. <a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1433?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

