### PR TITLE
docs(workflow): add Deploy-Components step type with example

### DIFF
--- a/docs/end-user/workflow/built-in-workflow-defs.md
+++ b/docs/end-user/workflow/built-in-workflow-defs.md
@@ -1348,6 +1348,71 @@ spec:
  env | Declare the name of the env in policy. | string | true |  |  
 
 
+## Deploy-Components
+
+### Description
+
+Deploy each component to the cluster(s) resolved from its own topology policies. Applies are executed sequentially, one at a time unlike "deploy", there is no parallelism setting to configure.
+
+### Scope
+
+This step type is only valid in Application.
+
+### Examples (deploy-components)
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: deploy-components-example
+  namespace: examples
+spec:
+  components:
+    - name: web-on-local
+      type: webservice
+      properties:
+        image: nginx
+    - name: web-on-worker
+      type: webservice
+      properties:
+        image: nginx
+  policies:
+    - name: topology-local
+      type: topology
+      properties:
+        clusters: ["local"]
+    - name: topology-worker
+      type: topology
+      properties:
+        clusters: ["cluster-worker"]
+  workflow:
+    steps:
+      - name: deploy-components
+        type: deploy-components
+        properties:
+          components:
+            - name: web-on-local
+              policies: ["topology-local"]
+            - name: web-on-worker
+              policies: ["topology-worker"]
+```
+
+### Specification (deploy-components)
+
+
+ Name | Description | Type | Required | Default | Immutable 
+ ---- | ----------- | ---- | -------- | ------- | --------- 
+ components | Per-component mapping of which topology policies determine its target cluster(s). | [[]components](#components-deploy-components) | true |  |  
+
+
+#### components (deploy-components)
+
+ Name | Description | Type | Required | Default | Immutable 
+ ---- | ----------- | ---- | -------- | ------- | --------- 
+ name | The name of the component in the application to apply. | string | true |  |  
+ policies | Names of topology policies (declared at the Application level) used to resolve this component's target cluster(s). | []string | true |  |  
+
+
 ## Export-Data
 
 ### Description


### PR DESCRIPTION
### Description of your changes

Adds documentation for the `deploy-components` built-in workflow step type,
introduced in kubevela/kubevela#7213.

The new **Deploy-Components** section is placed alphabetically under the
"Built-in Workflow Steps" page (after `Deploy-Cloud-Resource`), and follows the
same structure as the other built-in steps (`apply-component`,
`apply-deployment`, etc.): Description, Scope, Examples, and Specification.
The example and parameter spec mirror the definition's CUE `parameter` block
so they match what docgen would generate.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] ~~Update `sidebar.js` if adding a new page.~~ N/A — section added to an existing page (`end-user/workflow/built-in-workflow-defs`), no new page.
- [x] Run `yarn start` to ensure the changes has taken effect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add documentation for the `deploy-components` built-in workflow step. Explains sequential per-component deploys to clusters resolved by each component’s topology policies, with examples and spec.

- New Features
  - Added Deploy-Components section under Built-in Workflow Steps (after Deploy-Cloud-Resource), with Description and Scope.
  - Included a full Application example and the parameter spec for the `components` mapping (name, policies).

<sup>Written for commit 4e2213292fadc3eb5a0d97d26ba95a9432297a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

