### PR TITLE
Docs: CUE 0.14 compatibility layer for v1.11.0

### DIFF
--- a/docs/platform-engineers/system-operation/cue-compatibility-layer.md
+++ b/docs/platform-engineers/system-operation/cue-compatibility-layer.md
@@ -1,0 +1,126 @@
+---
+title: CUE 0.14 Compatibility Layer
+---
+
+Starting with v1.11.0, KubeVela upgrades its underlying CUE engine from v0.9.2 to v0.14.1. CUE v0.14 turns two previously-tolerated patterns into hard errors and enables two new experimental evaluator behaviors by default. Any ComponentDefinition, TraitDefinition, PolicyDefinition, or WorkflowStepDefinition written against the old rules can fail to render after the upgrade.
+
+To keep existing definitions working without requiring every operator to hand-edit CUE templates, KubeVela ships a compatibility layer that automatically rewrites legacy syntax at render time, plus CLI tooling to find and permanently fix affected definitions.
+
+## What changed in CUE v0.14
+
+- **List arithmetic** (`+`, `*` on lists) is now a hard error.
+- **Unquoted `error` field labels** (e.g. `error: "message"` instead of `"error": "message"`) are now a hard error.
+- **`evalv3`** (stricter cycle detection) and **`keepvalidators`** (concretization of validators) are enabled by default. Both can silently break definitions that conditionally refine `bool | *false` fields from optional parameters, or that rely on custom error messages surviving cycle detection.
+
+If your definitions were written before v1.11.0, assume at least one of these affects you until you've scanned them (see below).
+
+## The auto-remediation layer
+
+`pkg/cue/upgrade` (wired in via [#7199](https://github.com/kubevela/kubevela/pull/7199) and [#7215](https://github.com/kubevela/kubevela/pull/7215)) intercepts CUE templates at render time, detects legacy syntax, and rewrites it in memory before compilation. The definition stored in Kubernetes is never modified — only the copy used for rendering.
+
+The master switch and cache size were introduced first; the six per-pass toggles below were added afterward in [#7229](https://github.com/kubevela/kubevela/pull/7229), which split the engine into independently controllable passes. All are flags on the `kubevela-controller`:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--enable-cue-version-compatibility` | `true` | Master switch for the whole layer. Set to `false` to render templates exactly as written (fails hard on legacy syntax). |
+| `--cue-compatibility-cache-size` | `2000` | Max number of rewritten templates cached (1h TTL). Set to `0` to disable caching. |
+| `--cue-upgrade-list-concat-enabled` | `true` | Rewrite pass for list-arithmetic syntax. |
+| `--cue-upgrade-error-field-label-enabled` | `true` | Rewrite pass for unquoted error field labels. |
+| `--cue-upgrade-bool-default-guard-enabled` | `false` | Rewrite pass for the `bool \| *false` default-guard hazard under `evalv3`/`keepvalidators`. |
+| `--cue-upgrade-generic-default-guard-enabled` | `false` | Same as above, generalized to non-bool default guards. |
+| `--cue-upgrade-keepvalidators-singleton-enabled` | `false` | Rewrite pass for `keepvalidators` singleton concretization issues. |
+| `--cue-upgrade-evalv3-selfref-guard-enabled` | `false` | Rewrite pass for `evalv3` self-reference default-guard issues. |
+
+The two enabled-by-default passes (list concat, error field label) cover the syntax that is now a **hard error**. The four disabled-by-default passes address **behavioral** differences under `evalv3`/`keepvalidators` — turn them on only if you've confirmed you're hitting the specific hazard, since they change evaluation semantics rather than just syntax.
+
+These flags apply to both the main controller (`github.com/oam-dev/kubevela/pkg/cue/upgrade`) and the workflow engine (`github.com/kubevela/workflow` v0.7.0+, `pkg/cue/upgrade`) — WorkflowStepDefinitions are covered by the same switches, not just Component/Trait/Policy definitions.
+
+:::note Why these flags matter even though `evalv3`/`keepvalidators` are off by default
+The chart ships with `CUE_EXPERIMENT=evalv3=0,keepvalidators=0` (see below) purely to keep v1.11.0 compatible with definitions written against the older CUE v0.9.2 behavior — it is a temporary bridge for the v0.14.x window, not a permanent setting. If you want to start benefiting from `evalv3`'s stricter, more correct cycle detection now, you can flip `featureGates.enableCueExpVariable` to `false` (or clear `CUE_EXPERIMENT`) to turn it on ahead of time, and use the `--cue-upgrade-bool-default-guard-enabled`, `--cue-upgrade-generic-default-guard-enabled`, `--cue-upgrade-keepvalidators-singleton-enabled`, and `--cue-upgrade-evalv3-selfref-guard-enabled` passes to keep any legacy definitions that hit those specific hazards working while you do.
+
+In a future CUE release, `evalv3` (and `keepvalidators`) will no longer be gated behind an experiment at all — they'll simply be **on by default** with no `CUE_EXPERIMENT` opt-out. At that point `CUE_EXPERIMENT=evalv3=0,keepvalidators=0` stops having any effect, and these render-time rewrite passes become the only remaining mitigation for definitions that haven't been permanently fixed with `vela def upgrade`.
+:::
+
+## Disabling the breaking CUE experiments via Helm
+
+As a coarser alternative (or complement) to the render-time rewrite layer, the `vela-core` Helm chart can inject `CUE_EXPERIMENT` directly into the controller to turn off `evalv3` and `keepvalidators` at the CUE runtime level ([#7225](https://github.com/kubevela/kubevela/pull/7225)):
+
+```yaml
+featureGates:
+  # Injects CUE_EXPERIMENT=evalv3=0,keepvalidators=0 into the controller container.
+  # Default: true for the v1.11.x series, to keep the upgrade non-breaking out of the box.
+  enableCueExpVariable: true
+```
+
+For any other environment variable, use the general-purpose escape hatch:
+
+```yaml
+extraEnvs:
+  - name: SOME_OTHER_VAR
+    value: "some-value"
+```
+
+`extraEnvs` and `featureGates.enableCueExpVariable` are independent — if you need a different `CUE_EXPERIMENT` value than the chart default, set `featureGates.enableCueExpVariable: false` and provide your own `CUE_EXPERIMENT` entry under `extraEnvs` instead of setting both (the controller container would otherwise receive two `CUE_EXPERIMENT` env entries).
+
+```
+helm upgrade -n vela-system --install kubevela kubevela/vela-core \
+  --version 1.11.0 \
+  --set featureGates.enableCueExpVariable=false \
+  --set-json 'extraEnvs=[{"name":"CUE_EXPERIMENT","value":"evalv3=0,keepvalidators=0,otherflag=1"}]' \
+  --wait
+```
+
+## Finding affected definitions
+
+Scan every definition (and its revision history) across all namespaces for legacy syntax:
+
+```
+vela def compatibility-check definitions
+# alias: vela def compat definitions
+
+# only the current live definition, skip revision history
+vela def compatibility-check definitions --latest-revision-only
+
+# narrow by namespace / labels / annotations, or change output format
+vela def compatibility-check definitions -n my-namespace -o yaml
+```
+
+Scan active `ApplicationRevisions` to see which running applications are relying on the compatibility layer right now:
+
+```
+vela def compatibility-check applications
+# alias: vela def compat applications
+```
+
+Both commands report, per definition or application, which specific incompatibility was found, the CUE version that introduced it, and the affected revisions — so you know exactly what to fix and where.
+
+## Permanently fixing a definition
+
+Once you know a definition needs updating, rewrite it on disk rather than relying on the render-time layer indefinitely:
+
+```
+# check if a file needs upgrading (exit code 1 if so), without modifying it
+vela def upgrade my-definition.cue --validate
+
+# rewrite in place
+vela def upgrade my-definition.cue
+
+# write the rewritten version to a new file
+vela def upgrade my-definition.cue -o my-definition.upgraded.cue
+
+# target a specific KubeVela version's compatibility rules
+vela def upgrade my-definition.cue --target-version=v1.11
+```
+
+`vela def apply` also warns at apply time when the definition being applied contains syntax the compatibility layer would otherwise need to rewrite.
+
+## Recommended upgrade path
+
+1. Upgrade the `vela-core` chart to v1.11.0. `featureGates.enableCueExpVariable` defaults to `true` and `--enable-cue-version-compatibility` defaults to `true` on the controller, so existing applications keep working immediately.
+2. Run `vela def compatibility-check definitions` and `vela def compatibility-check applications` to see what's relying on the compatibility layer.
+3. Run `vela def upgrade` against each affected definition file and re-apply it, so the stored definition itself is CUE v0.14-native.
+4. Once nothing is flagged by `vela def compatibility-check`, you can leave the compatibility layer enabled (it's a no-op for compliant definitions) or disable it with `--enable-cue-version-compatibility=false` for stricter enforcement going forward.
+
+## Known limitation
+
+Workflow step templates evaluated at execution time by the `kubevela/workflow` engine were not covered by the compatibility layer prior to `kubevela/workflow` v0.7.0. KubeVela v1.11.0 bundles v0.7.0 or later, which wires in the same rewrite passes — if you're consuming `kubevela/workflow` independently of the `vela-core` chart, confirm you're on v0.7.0+.

--- a/docs/platform-engineers/system-operation/migration-from-old-version.md
+++ b/docs/platform-engineers/system-operation/migration-from-old-version.md
@@ -6,6 +6,39 @@ This doc aims to provide a migration guide from old versions to the new ones wit
 
 KubeVela has [release cadence](../../contributor/release-process.md) for every 2-3 months, we'll only maintain for the last 2 releases. As a result, you're highly recommended to upgrade along with the community. We'll strictly align with the [semver version rule](https://semver.org/) for compatibility.
 
+## From v1.10.x to v1.11.x
+
+v1.11.x upgrades the underlying CUE engine from v0.9.2 to v0.14.1. CUE v0.14 turns previously-tolerated syntax (list arithmetic, unquoted error field labels) into hard errors, and enables two new experimental evaluator behaviors (`evalv3`, `keepvalidators`) that can change how existing definitions behave.
+
+:::note
+This upgrade is non-breaking by default. The controller renders legacy definitions through an automatic compatibility layer, and the Helm chart disables the two breaking CUE experiments out of the box. See [CUE 0.14 Compatibility Layer](cue-compatibility-layer.md) for the full reference, flags, and CLI tooling to find and permanently fix affected definitions.
+:::
+
+1. Upgrade your kubevela chart
+
+```
+helm repo add kubevela https://kubevela.github.io/charts
+helm repo update
+helm upgrade -n vela-system --install kubevela kubevela/vela-core --version 1.11.0 --wait
+```
+
+2. (Optional, recommended) Scan for definitions relying on the compatibility layer, and permanently upgrade them:
+
+```
+vela def compatibility-check definitions
+vela def upgrade my-definition.cue
+```
+
+### Toolchain and dependency bumps
+
+v1.11.x also raises the Go toolchain and Kubernetes client library versions used to build and run KubeVela:
+
+- **Go**: `1.22.0` → `1.23.8` ([#6767](https://github.com/kubevela/kubevela/pull/6767))
+- **Kubernetes client libraries** (`k8s.io/api`, `k8s.io/client-go`, `k8s.io/apimachinery`, etc.): `v0.29.2` → `v0.31.10`, and `sigs.k8s.io/controller-runtime`: `v0.17.6` → `v0.19.7` ([#6837](https://github.com/kubevela/kubevela/pull/6837))
+- E2E tests and envtest now run against Kubernetes `v1.31` (previously `v1.29`)
+
+These are neither breaking for end users nor for existing Application/Definition YAML. They matter if you build custom controllers, providers, or addons against KubeVela's Go modules — bump your own `go.mod` and vendored `k8s.io`/`controller-runtime` versions accordingly to stay within a compatible range. The supported Kubernetes cluster version for running KubeVela itself remains `>= v1.19 && <= v1.31` (see [Kubernetes Requirements](../../installation/kubernetes.mdx)).
+
 ## From v1.8.x to v1.9.x
 
 :::caution

--- a/sidebars.js
+++ b/sidebars.js
@@ -238,6 +238,7 @@ module.exports = {
             'platform-engineers/system-operation/controller-grayscale-release',
             'platform-engineers/system-operation/high-availability',
             'platform-engineers/system-operation/migration-from-old-version',
+            'platform-engineers/system-operation/cue-compatibility-layer',
           ],
         },
         {


### PR DESCRIPTION
## Summary

KubeVela v1.11.0 upgrades the CUE engine from v0.9.2 to v0.14.1. CUE v0.14 turns
previously-tolerated syntax (list arithmetic, unquoted `error` field labels) into
hard errors, and enables two new experimental evaluator behaviors (`evalv3`,
`keepvalidators`) that can change how existing definitions behave. This adds
documentation for the compatibility layer that keeps the upgrade non-breaking,
and for the toolchain/dependency bumps that shipped alongside it.

- New reference page: `docs/platform-engineers/system-operation/cue-compatibility-layer.md`
  - What changed in CUE v0.14 and why it matters
  - The render-time auto-remediation layer and its controller flags (master switch,
    cache size, and the six per-pass toggles), with defaults
  - The Helm chart's `extraEnvs` / `featureGates.enableCueExpVariable` controls for
    disabling the breaking CUE experiments via `CUE_EXPERIMENT`, and why the
    per-pass flags still matter even with that default in place (temporary
    bridge for the v0.14.x window vs. a future CUE release where `evalv3`/
    `keepvalidators` are on by default with no opt-out)
  - `vela def compatibility-check` / `vela def upgrade` CLI usage to find and
    permanently fix affected definitions
  - A recommended upgrade path and a known limitation around workflow step
    templates
- New `## From v1.10.x to v1.11.x` section in
  `docs/platform-engineers/system-operation/migration-from-old-version.md`,
  linking to the new page, plus a note on the Go and Kubernetes dependency bumps
  that shipped in the same window
- Registers the new page in `sidebars.js` under Operator Manual → Production
  Precautions

## Related kubevela/kubevela PRs

- kubevela/kubevela#6767 — Go `1.22.0` → `1.23.8`
- kubevela/kubevela#6837 — Kubernetes client libraries `v0.29.2` → `v0.31.10`,
  `controller-runtime` `v0.17.6` → `v0.19.7`
- kubevela/kubevela#7199 — CUE 0.14 auto-remediation compatibility layer
  (`pkg/cue/upgrade`, `vela def upgrade`/`compat`)
- kubevela/kubevela#7215 — wires the compatibility engine into the template loader
- kubevela/kubevela#7225 — `extraEnvs` Helm value to control `CUE_EXPERIMENT`
- kubevela/kubevela#7229 — per-pass controller flags/Helm values for the
  compatibility layer

## Test plan

- [x] `sidebars.js` parses (`node -e "require('./sidebars.js')"`)
- [x] `yarn build` / local Docusaurus preview (not run in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for the CUE 0.14 compatibility layer in v1.11.0 to keep upgrades non-breaking, including render-time auto-remediation, Helm `CUE_EXPERIMENT` controls, and `vela def` tooling. Updates the migration guide and sidebar, and notes Go/Kubernetes dependency bumps and test env changes.

- **Migration**
  - New reference page covering v0.14 changes, master switch, cache, and six pass-level flags (with defaults) for both the controller and `kubevela/workflow` v0.7.0+.
  - Helm docs for `featureGates.enableCueExpVariable` (defaults to `CUE_EXPERIMENT=evalv3=0,keepvalidators=0`) and `extraEnvs`, with guidance on when per-pass rewrites still matter.
  - CLI: `vela def compatibility-check definitions|applications`, `vela def upgrade`, plus `vela def apply` warnings; recommended upgrade path and workflow < v0.7.0 limitation.
  - Migration guide adds “From v1.10.x to v1.11.x,” links to the page, notes non-breaking defaults; E2E/envtest on Kubernetes v1.31 and supported cluster range (>=1.19, <=1.31). Sidebar entry added.

- **Dependencies**
  - Go `1.22.0` → `1.23.8`.
  - Kubernetes client libs `v0.29.2` → `v0.31.10`; `controller-runtime` `v0.17.6` → `v0.19.7`.

<sup>Written for commit f4b79fd4801670e693fc623bd5f3b3d2031614b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

