### PR TITLE
fix: use npm install instead of npm ci in issue-commands workflow (un…

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -22,7 +22,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: ./actions/package-lock.json
       - name: Install Dependencies
-        run: npm ci --production --prefix ./actions
+        # NOTE: using `npm install` instead of `npm ci` as a workaround because the
+        # package-lock.json in oam-dev/kubevela-github-actions@v0.4.2 is out of sync
+        # with package.json, which makes `npm ci` fail with EUSAGE. Revert to `npm ci`
+        # once the lock file is fixed upstream (or a newer tag is pinned).
+        run: npm install --omit=dev --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands
         with:


### PR DESCRIPTION
…blocks CI)

### Description of your changes

The bot workflow checks out oam-dev/kubevela-github-actions@v0.4.2 fresh on every run and installs its dependencies with `npm ci --production`. That repo's package-lock.json is out of sync with its package.json (confirmed by cloning the tag and reproducing the exact EUSAGE failure locally), so `npm ci` refuses to install and every labeled/commented issue run fails at the "Install Dependencies" step.

Switch to `npm install --omit=dev`, which tolerates a stale lock file by resolving and installing anyway. This is a workaround, not a root-cause fix; the lock file needs to be regenerated and committed upstream in `oam-dev/kubevela-github-actions`, after which this should revert to `npm ci` for reproducible installs.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the issue-commands workflow to `npm install --omit=dev` to work around an upstream stale lockfile and unblock CI runs.

- **Bug Fixes**
  - Replaced `npm ci --production` with `npm install --omit=dev` in `.github/workflows/issue-commands.yml` to tolerate the out-of-sync lockfile in `oam-dev/kubevela-github-actions@v0.4.2`. Revert to `npm ci` when the upstream lockfile is fixed.

<sup>Written for commit 6ca8196888e5023d5ecabb977096831f8e33168f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

