### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
+
+*                                  @anoop2811 @FogDong @StevenLeiZhang @briankane @jguionnet @roguepikachu


### PR DESCRIPTION
## Summary
- Add @roguepikachu to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/271
- Related: https://github.com/kubevela/community/pull/272

## Test plan
- [ ] Confirm @roguepikachu is listed on owned paths
- [ ] Maintainer/reviewer approval


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a repository-wide CODEOWNERS file and include `@roguepikachu` in the global owners list so they’re auto-requested for reviews. This clarifies ownership and ensures coverage across all paths.

<sup>Written for commit f3ea7afab506851f087a693d972fed8213db1b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

