### PR TITLE
Docs: expand contributor guide with DCO, security and governance links

### DIFF
--- a/docs/contributor/code-contribute.md
+++ b/docs/contributor/code-contribute.md
@@ -6,6 +6,7 @@ You will learn the following things in the code contribution guide:
 
 - [How to Run KubeVela Locally](#run-kubevela-locally)
 - [How to Run VelaUX Locally](#run-velaux-locally)
+- [How to Sign Your Commits (DCO)](#sign-your-commits-dco)
 - [How to Create a pull request](#create-a-pull-request)
 - [Code Review Guide](#code-review)
 - [Formatting guidelines of pull request](#formatting-guidelines)
@@ -356,6 +357,44 @@ mv ~/.kube/config.save  ~/.kube/config
 make e2e-apiserver-test
 ```
 
+## Sign Your Commits (DCO)
+
+KubeVela uses the Developer Certificate of Origin instead of a CLA. The [DCO](https://developercertificate.org) is a short statement saying you wrote the code you're submitting, or otherwise have the right to submit it under the project's license. You agree to it by adding a `Signed-off-by` line to each commit, there's no separate document to sign. See the [Linux Foundation DCO page](https://wiki.linuxfoundation.org/dco) for background.
+
+Git can add that line for you with the `-s` flag:
+
+```shell
+git commit -s -m 'This is my commit message'
+```
+
+This produces a trailer like the following at the end of the commit message:
+
+```
+This is my commit message
+
+Signed-off-by: Random Developer <random@developer.example.org>
+```
+
+The email in the sign-off must match the email on your GitHub account, otherwise your pull request may not be able to merge.
+
+### Fixing a missing sign-off
+
+If only your most recent commit is missing the sign-off:
+
+```shell
+git commit --amend --signoff
+git push --force-with-lease
+```
+
+If several commits in your pull request need signing off, rebase the whole branch with sign-off. `<base-branch>` is the branch your pull request targets, usually `master`:
+
+```shell
+git rebase --signoff <base-branch>
+git push --force-with-lease
+```
+
+Since KubeVela squashes pull requests on merge, every source commit still needs a valid sign-off before the pull request can be merged. The squashed commit takes its message from the pull request rather than from any single source commit, so signing off one commit is not enough.
+
 ## Create a pull request
 
 We're excited that you're considering making a contribution to the KubeVela project!
@@ -505,17 +544,7 @@ Make sure that the title for your pull request uses the same format as the subje
 
 Before merge, All test CI should pass green.
 - The `codecov/project` should also pass. This means the coverage should not drop. Currently, the coverage of the Pull Request should have at least 70%.
-- KubeVela uses [DCO](https://wiki.linuxfoundation.org/dco) for contributor agreements. It requires you to sign-off every commit before the pull request being merged.
-  - Git provides a convenient flag `-s` in your commit command to sign-off automatically:
-    ```shell
-    git commit -s -m 'This is my commit message'
-    ```
-  - Contributors can also sign-off manually by adding a `Signed-off-by` line to commit messages as the following format, make sure the email matches your github account or the check bot won't pass.
-    ```shell
-    This is my commit message
-
-    Signed-off-by: Random Developer <random@developer.example.org>
-    ```
+- Make sure every commit is signed off per the [DCO](#sign-your-commits-dco) requirements.
 
 ## Update the docs & website
 

--- a/docs/contributor/non-code-contribute.md
+++ b/docs/contributor/non-code-contribute.md
@@ -15,7 +15,7 @@ You can pick up any of the following ways you're interested to contribute.
 Before submitting a new issue, try to make sure someone hasn't already reported the problem.
 Look through the [existing issues](https://github.com/kubevela/kubevela/issues) for similar issues.
 
-Report a bug by submitting a [bug report](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=kind%2Fbug&template=bug_report.md&title=).
+Report a bug by submitting a [bug report](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=type%2Fbug&template=bug_report.yml&title=).
 Make sure that you provide as much information as possible on how to reproduce the bug.
 
 Follow the issue template and add additional information that will help us replicate the problem.
@@ -26,7 +26,7 @@ If you believe you've found a security vulnerability, please read our [security 
 
 ## Suggest enhancements
 
-If you have an idea to improve KubeVela, submit an [feature request](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=kind%2Ffeature&template=feature_request.md&title=%5BFeature%5D).
+If you have an idea to improve KubeVela, submit an [feature request](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=type%2Ffeature&template=feature_request.yml&title=%5BFeature%5D).
 
 ## Triage issues
 

--- a/docs/contributor/non-code-contribute.md
+++ b/docs/contributor/non-code-contribute.md
@@ -7,7 +7,7 @@ You can pick up any of the following ways you're interested to contribute.
 ## Contribute Use cases and Samples
 
 * If you're using KubeVela, the easiest thing to contribute is to [credit the community](https://github.com/kubevela/kubevela/issues/1662).
-* If you are interested, you can also write a [kubevela.io blog](https://kubevela.net/blog) to tell more about the use case.
+* If you are interested, you can also write a [kubevela.io blog](https://kubevela.io/blog) to tell more about the use case.
 * You can also contribute to [KubeVela Official Samples](https://github.com/kubevela/samples).
 
 ## Report bugs

--- a/docs/contributor/non-code-contribute.md
+++ b/docs/contributor/non-code-contribute.md
@@ -24,9 +24,10 @@ Follow the issue template and add additional information that will help us repli
 
 If you believe you've found a security vulnerability, please read our [security policy](https://github.com/kubevela/kubevela/blob/master/SECURITY.md) for more details.
 
-## Suggest enhancements
+## Suggest features and enhancements
 
-If you have an idea to improve KubeVela, submit an [feature request](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=type%2Ffeature&template=feature_request.yml&title=%5BFeature%5D).
+If you have an idea for something that doesn't exist yet, submit a [feature request](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=type%2Ffeature&template=feature_request.yml&title=%5BFeature%5D).
+If you want to improve something that's already there, submit an [enhancement request](https://github.com/kubevela/kubevela/issues/new?assignees=&labels=type%2Fenhancement&template=enhancement_request.yml&title=%5BEnhancement%5D).
 
 ## Triage issues
 

--- a/docs/contributor/overview.md
+++ b/docs/contributor/overview.md
@@ -31,9 +31,19 @@ As a result, you can extend more powerful features for your platform.
 
 KubeVela project is initialized and maintained by the cloud native community since day 0 with [bootstrapping contributors from 8+ different organizations](https://github.com/kubevela/community/blob/main/OWNERS.md#bootstrap-contributors). We intend for KubeVela to have an open governance since the very beginning and donate the project to neutral foundation as soon as it's released. 
 
-To help us create a safe and positive community experience for all, we require all participants adhere to the CNCF Community [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Two things apply to everyone. To help us create a safe and positive community experience for all, we require all participants adhere to the CNCF Community [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). And every contribution requires you to sign off your commits under the Developer Certificate of Origin, see [Sign Your Commits (DCO)](./code-contribute.md#sign-your-commits-dco) for how to do that.
 
 This part is a guide to help you through the process of contributing to KubeVela.
+
+### First-time contributor checklist
+
+If you're contributing code for the first time, work through these in order:
+
+1. Read the CNCF Community [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+2. Set up your local development environment by following [Run KubeVela Locally](./code-contribute.md#run-kubevela-locally).
+3. Pick up something to work on from the [good first issue](https://github.com/kubevela/kubevela/labels/good%20first%20issue) list.
+4. Sign off your commits with `git commit -s`, see [Sign Your Commits (DCO)](./code-contribute.md#sign-your-commits-dco).
+5. Run `make reviewable` before you open the pull request, see [Your first pull request](./code-contribute.md#your-first-pull-request).
 
 ### Become a contributor
 
@@ -44,6 +54,10 @@ we appreciate every effort you contribute to the community. Here are some exampl
 * Report and triage issues.
 * Organize meetups and user groups in your local area.
 * Help others by answering questions about KubeVela.
+
+### Communication
+
+The community talks on the CNCF Slack channel `#kubevela-dev`, on DingTalk and WeChat groups, and in the weekly community meetings. The joining links, group IDs and meeting schedule all live in one place, see [community communication](https://github.com/kubevela/community#communication).
 
 ### Non-code contribution
 
@@ -61,9 +75,15 @@ Unsure where to begin contributing to KubeVela codebase? Start by browsing issue
 
 Learn the [Release Process And Cadence](./release-process.md) to know when your code changes will be released.
 
-### Become a community member
+### Security
 
-If you're interested to become a community member or learn more about the governance, please check the [community membership](https://github.com/kubevela/community/blob/main/community-membership.md) for details.
+If you find a security vulnerability, report it privately as described in the [security policy](https://github.com/kubevela/kubevela/blob/master/SECURITY.md) rather than filing a public issue.
+
+### Governance & membership
+
+KubeVela has a role ladder that goes Member, Reviewer, Approver, Maintainer, with each step carrying more review and approval responsibility for the project. Roles are earned through sustained contribution, and the requirements for each one are written down in [community membership](https://github.com/kubevela/community/blob/main/community-membership.md).
+
+To see who currently holds which role, check [OWNERS](https://github.com/kubevela/community/blob/main/OWNERS.md). For how the project makes decisions, read the [governance](https://github.com/kubevela/community/blob/main/GOVERNANCE.md) document.
 
 ### Contribute to other community projects
 

--- a/docs/contributor/overview.md
+++ b/docs/contributor/overview.md
@@ -57,7 +57,7 @@ we appreciate every effort you contribute to the community. Here are some exampl
 
 ### Communication
 
-The community talks on the CNCF Slack channel `#kubevela-dev`, on DingTalk and WeChat groups, and in the weekly community meetings. The joining links, group IDs and meeting schedule all live in one place, see [community communication](https://github.com/kubevela/community#communication).
+The community talks on the CNCF Slack channel [`#kubevela`](https://cloud-native.slack.com/archives/C01BLQ3HTJA), on DingTalk and WeChat groups, and in the weekly community meetings. The joining links, group IDs and meeting schedule all live in one place, see [community communication](https://github.com/kubevela/community#communication).
 
 ### Non-code contribution
 


### PR DESCRIPTION
This restructures the contributor overview page and the code contribution page so DCO, security reporting, and governance are easy to find instead of buried or missing.

On docs/contributor/overview.md: the Code of Conduct mention now sits near the top alongside a DCO one-liner, there's a new first-time contributor checklist right after the intro, a Communication section pointing to the community repo's Slack, DingTalk, WeChat and meeting info, a Security section pointing to SECURITY.md, and a Governance & membership section that explains the Member, Reviewer, Approver, Maintainer ladder and links to where roles and decisions are documented.

On docs/contributor/code-contribute.md: DCO gets its own top-level section, Sign Your Commits (DCO), instead of being a bullet buried under the CI checks list. It explains what DCO is, how to sign off with `git commit -s`, and gives concrete commands for fixing a commit that's missing a sign-off, amend for the last commit, rebase --signoff for several commits. The old bullet under the CI checks section now just points to this new section instead of repeating the instructions. I also softened a line that claimed a specific bot enforces the email match, since I couldn't confirm that check still exists on recent PRs, and didn't want the docs asserting a mechanism that might not be there.

On docs/contributor/non-code-contribute.md: the bug report and feature request links used labels=kind/bug and labels=kind/feature, which don't match this project's actual type/bug and type/feature label convention (looks copied from a Kubernetes-style template and never updated). Fixed those, and updated the template query params to the new .yml issue forms from the companion kubevela/kubevela PR.

Companion PRs:
- kubevela/kubevela (CONTRIBUTING.md, issue templates, .github fixes): https://github.com/kubevela/kubevela/pull/7337
- kubevela/community (GOVERNANCE.md stale domain fix)

Only the unversioned docs/contributor/ files are touched, nothing under versioned_docs/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises DCO, security, and governance visibility in contributor docs and fixes stale links, so new contributors can find the right guidance and issue templates quickly.

- Promotes DCO into its own section with `git commit -s`, amend, and `rebase --signoff` commands; CI checklist now links to it. Confirms squash merges still require every commit to be signed. Verify the `<base-branch>` example (“master”) matches the default branch.
- Adds a first-time contributor checklist; updates Communication to CNCF Slack `#kubevela` (archive link), DingTalk/WeChat, and meetings; adds Security (`SECURITY.md`) and Governance & membership (`GOVERNANCE.md`, `community-membership.md`, `OWNERS.md`). Fixes the kubevela.io blog link.
- Updates non-code issue links to use `.yml` forms with `type/bug`, `type/feature`, and a separate `type/enhancement` template. Ensure these forms exist in `kubevela/kubevela`.
- Limits scope to unversioned `docs/contributor/`; no migration required.

<sup>Written for commit d1bdf6357a074abe0eae11dd72ca243aba670215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

