### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*                                  @anoop2811 @FogDong @StevenLeiZhang @briankane @jguionnet @roguepikachu
+*                                  @anoop2811 @FogDong @StevenLeiZhang @briankane @jguionnet @roguepikachu @jerrinfrancis


### PR DESCRIPTION
## Summary
- Add @jerrinfrancis to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/274
- Related: https://github.com/kubevela/community/pull/275

## Test plan
- [ ] Confirm @jerrinfrancis is listed on owned paths
- [ ] Maintainer/reviewer approval

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@jerrinfrancis` to the global `*` entry in `.github/CODEOWNERS` so GitHub auto-requests their review across the repository. Previously not included; now included, increasing their review notifications.

- Only change: update `.github/CODEOWNERS`; no build or runtime impact.
- No action required; takes effect on new and updated PRs after merge.

<sup>Written for commit 851d04e4ec73a6f009560e427e0826052a70545d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/kubevela.github.io/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

